### PR TITLE
Data lossless automatic schema modification

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/configuration/ArgumentExtractor.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/configuration/ArgumentExtractor.java
@@ -16,24 +16,7 @@
 
 package info.archinnov.achilles.configuration;
 
-import static info.archinnov.achilles.configuration.ConfigurationParameters.BEAN_VALIDATION_ENABLE;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.BEAN_VALIDATION_VALIDATOR;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_READ_DEFAULT;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_READ_MAP;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_WRITE_DEFAULT;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_WRITE_MAP;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.ENTITIES_LIST;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.ENTITY_PACKAGES;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.EVENT_INTERCEPTORS;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_BATCH_STATEMENTS_ORDERING;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_TABLE_CREATION;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.INSERT_STRATEGY;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.KEYSPACE_NAME;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.NATIVE_SESSION;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.OBJECT_MAPPER;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.OBJECT_MAPPER_FACTORY;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.PREPARED_STATEMENTS_CACHE_SIZE;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.PROXIES_WARM_UP_DISABLED;
+import static info.archinnov.achilles.configuration.ConfigurationParameters.*;
 import static javax.validation.Validation.buildDefaultValidatorFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,6 +102,8 @@ public class ArgumentExtractor {
 
         ConfigurationContext configContext = new ConfigurationContext();
         configContext.setForceColumnFamilyCreation(initForceTableCreation(configurationMap));
+        configContext.setForceColumnFamilyUpdate(initForceTableUpdate(configurationMap));
+        configContext.setForceColumnFamilyUpdateMap(initForceTableUpdateMap(configurationMap));
         configContext.setObjectMapperFactory(initObjectMapperFactory(configurationMap));
         configContext.setDefaultReadConsistencyLevel(initDefaultReadConsistencyLevel(configurationMap));
         configContext.setDefaultWriteConsistencyLevel(initDefaultWriteConsistencyLevel(configurationMap));
@@ -132,7 +117,30 @@ public class ArgumentExtractor {
     boolean initForceTableCreation(ConfigMap configurationMap) {
         log.trace("Extract 'force table creation' from configuration map");
 
-        Boolean forceColumnFamilyCreation = configurationMap.getTyped(FORCE_TABLE_CREATION);
+        return findParamOrFalse(configurationMap, FORCE_TABLE_CREATION);
+    }
+
+    boolean initForceTableUpdate(ConfigMap configurationMap) {
+        log.trace("Extract 'force table update' from configuration map");
+
+        return findParamOrFalse(configurationMap, FORCE_TABLE_UPDATE);
+    }
+
+    public Map<String, Boolean> initForceTableUpdateMap(ConfigMap configMap) {
+        log.trace("Extract 'force table update' map from configuration map");
+
+        Map<String, String> forceTableUpdateMap = configMap.getTyped(FORCE_TABLE_UPDATE_MAP);
+        Map<String, Boolean> result = new HashMap<>();
+        if (forceTableUpdateMap != null && !forceTableUpdateMap.isEmpty()) {
+            for (Entry<String, String> entry : forceTableUpdateMap.entrySet()) {
+                result.put(entry.getKey(), Boolean.valueOf(entry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    private boolean findParamOrFalse(ConfigMap configurationMap, ConfigurationParameters key) {
+        Boolean forceColumnFamilyCreation = configurationMap.getTyped(key);
         if (forceColumnFamilyCreation != null) {
             return forceColumnFamilyCreation;
         } else {

--- a/achilles-core/src/main/java/info/archinnov/achilles/configuration/ConfigurationParameters.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/configuration/ConfigurationParameters.java
@@ -16,8 +16,6 @@
 
 package info.archinnov.achilles.configuration;
 
-import info.archinnov.achilles.type.ConsistencyLevel;
-
 public enum ConfigurationParameters {
     ENTITY_PACKAGES("achilles.entity.packages"),
     ENTITIES_LIST("achilles.entities.list"),
@@ -36,6 +34,9 @@ public enum ConfigurationParameters {
     EVENT_INTERCEPTORS("achilles.event.interceptors"),
 
     FORCE_TABLE_CREATION("achilles.ddl.force.table.creation"),
+
+    FORCE_TABLE_UPDATE("achilles.ddl.force.table.update"),
+    FORCE_TABLE_UPDATE_MAP("achilles.ddl.force.table.update.map"),
 
     BEAN_VALIDATION_ENABLE("achilles.bean.validation.enable"),
     BEAN_VALIDATION_VALIDATOR("achilles.bean.validation.validator"),

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/context/ConfigurationContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/context/ConfigurationContext.java
@@ -23,8 +23,14 @@ import info.archinnov.achilles.json.ObjectMapperFactory;
 import info.archinnov.achilles.type.ConsistencyLevel;
 import info.archinnov.achilles.type.InsertStrategy;
 
+import java.util.Map;
+
 public class ConfigurationContext {
     private boolean forceColumnFamilyCreation;
+
+    private boolean forceColumnFamilyUpdate;
+
+    private Map<String, Boolean> forceColumnFamilyUpdateMap;
 
     private ObjectMapperFactory objectMapperFactory;
 
@@ -48,6 +54,22 @@ public class ConfigurationContext {
 
     public void setForceColumnFamilyCreation(boolean forceColumnFamilyCreation) {
         this.forceColumnFamilyCreation = forceColumnFamilyCreation;
+    }
+
+    public boolean isForceColumnFamilyUpdate() {
+        return forceColumnFamilyUpdate;
+    }
+
+    public void setForceColumnFamilyUpdateMap(Map<String, Boolean> forceColumnFamilyUpdateMap) {
+        this.forceColumnFamilyUpdateMap = forceColumnFamilyUpdateMap;
+    }
+
+    public Map<String, Boolean> getForceColumnFamilyUpdateMap() {
+        return forceColumnFamilyUpdateMap;
+    }
+
+    public void setForceColumnFamilyUpdate(boolean forceColumnFamilyUpdate) {
+        this.forceColumnFamilyUpdate = forceColumnFamilyUpdate;
     }
 
     public ObjectMapperFactory getObjectMapperFactory() {

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/context/SchemaContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/context/SchemaContext.java
@@ -25,6 +25,7 @@ import com.datastax.driver.core.TableMetadata;
 import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
 import info.archinnov.achilles.internal.metadata.parsing.context.ParsingResult;
 import info.archinnov.achilles.internal.table.TableCreator;
+import info.archinnov.achilles.internal.table.TableUpdater;
 import info.archinnov.achilles.internal.table.TableValidator;
 
 public class SchemaContext {
@@ -43,6 +44,8 @@ public class SchemaContext {
     private TableCreator tableCreator = new TableCreator();
 
     private TableValidator tableValidator = new TableValidator();
+
+    private TableUpdater tableUpdater = new TableUpdater();
 
     public SchemaContext(boolean forceColumnFamilyCreation, Session session, String keyspaceName, Cluster cluster,
                          ParsingResult parsingResult) {
@@ -84,5 +87,9 @@ public class SchemaContext {
 
     public void createTableForCounter() {
         tableCreator.createTableForCounter(session, forceColumnFamilyCreation);
+    }
+
+    public void updateForEntity(EntityMeta entityMeta, TableMetadata tableMetaData) {
+        tableUpdater.updateTableForEntity(session, entityMeta, tableMetaData);
     }
 }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapper.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapper.java
@@ -73,7 +73,9 @@ public class AchillesBootstrapper {
             String tableName = entityMeta.getTableName().toLowerCase();
 
             if (tableMetaDatas.containsKey(tableName)) {
-                schemaContext.validateForEntity(entityMeta, tableMetaDatas.get(tableName));
+                TableMetadata tableMetaData = tableMetaDatas.get(tableName);
+                schemaContext.validateForEntity(entityMeta, tableMetaData);
+                schemaContext.updateForEntity(entityMeta, tableMetaData);
             } else {
                 schemaContext.createTableForEntity(entry.getValue());
             }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/holder/EntityMeta.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/holder/EntityMeta.java
@@ -73,6 +73,7 @@ public class EntityMeta {
     private boolean clusteredCounter = false;
     private List<Interceptor<?>> interceptors = new ArrayList<>();
     private InsertStrategy insertStrategy;
+    private boolean schemaUpdateEnabled = false;
 
     public Object getPrimaryKey(Object entity) {
         return idMeta.getPrimaryKey(entity);
@@ -212,6 +213,14 @@ public class EntityMeta {
 
     public void setInsertStrategy(InsertStrategy insertStrategy) {
         this.insertStrategy = insertStrategy;
+    }
+
+    public boolean isSchemaUpdateEnabled() {
+        return schemaUpdateEnabled;
+    }
+
+    public void setSchemaUpdateEnabled(boolean schemaUpdateEnabled) {
+        this.schemaUpdateEnabled = schemaUpdateEnabled;
     }
 
     @SuppressWarnings("unchecked")

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/holder/EntityMetaBuilder.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/holder/EntityMetaBuilder.java
@@ -43,6 +43,7 @@ public class EntityMetaBuilder {
     private Map<String, PropertyMeta> propertyMetas;
     private Pair<ConsistencyLevel, ConsistencyLevel> consistencyLevels;
     private InsertStrategy insertStrategy;
+    private boolean schemaUpdateEnabled;
 
     public static EntityMetaBuilder entityMetaBuilder(PropertyMeta idMeta) {
         return new EntityMetaBuilder(idMeta);
@@ -71,6 +72,7 @@ public class EntityMetaBuilder {
         meta.setSetterMetas(Collections.unmodifiableMap(extractSetterMetas(propertyMetas)));
         meta.setConsistencyLevels(consistencyLevels);
         meta.setInsertStrategy(insertStrategy);
+        meta.setSchemaUpdateEnabled(schemaUpdateEnabled);
 
         List<PropertyMeta> allMetasExceptId = new ArrayList<>(from(propertyMetas.values()).filter(excludeIdType)
                 .toList());
@@ -141,6 +143,11 @@ public class EntityMetaBuilder {
 
     public EntityMetaBuilder insertStrategy(InsertStrategy insertStrategy) {
         this.insertStrategy = insertStrategy;
+        return this;
+    }
+
+    public EntityMetaBuilder schemaUpdateEnabled(boolean value) {
+        this.schemaUpdateEnabled = value;
         return this;
     }
 }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/parsing/EntityParser.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/parsing/EntityParser.java
@@ -81,7 +81,7 @@ public class EntityParser {
         EntityMeta entityMeta = entityMetaBuilder(idMeta).entityClass(entityClass)
                 .className(entityClass.getCanonicalName()).columnFamilyName(columnFamilyName)
                 .propertyMetas(context.getPropertyMetas()).consistencyLevels(context.getCurrentConsistencyLevels())
-                .insertStrategy(insertStrategy)
+                .insertStrategy(insertStrategy).schemaUpdateEnabled(context.isSchemaUpdateEnabled(columnFamilyName))
                 .build();
 
         log.trace("Entity meta built for entity class {} : {}", context.getCurrentEntityClass().getCanonicalName(),

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/parsing/context/EntityParsingContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/parsing/context/EntityParsingContext.java
@@ -96,6 +96,14 @@ public class EntityParsingContext {
                 configContext.getDefaultWriteConsistencyLevel());
     }
 
+    public boolean isSchemaUpdateEnabled(String columnFamilyName) {
+        Map<String, Boolean> columnFamilyUpdateMap = configContext.getForceColumnFamilyUpdateMap();
+        if (columnFamilyUpdateMap.containsKey(columnFamilyName)) {
+            return columnFamilyUpdateMap.get(columnFamilyName);
+        }
+        return configContext.isForceColumnFamilyUpdate();
+    }
+
     public InsertStrategy getDefaultInsertStrategy() {
         return configContext.getInsertStrategy();
     }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/table/AbstractTableBuilder.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/table/AbstractTableBuilder.java
@@ -1,0 +1,36 @@
+package info.archinnov.achilles.internal.table;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
+
+public abstract class AbstractTableBuilder {
+
+	protected Set<IndexProperties> indexedColumns = new HashSet<>();
+
+	public boolean hasIndices() {
+		return indexedColumns.size() > 0;
+	}
+
+	public Collection<String> generateIndices(Collection<IndexProperties> indexedColumns, String tableName) {
+		Collection<String> indicesScripts = new LinkedList<>();
+		if (hasIndices()) {
+			for (IndexProperties indexProperties : indexedColumns) {
+				String indexName = indexProperties.getName();
+				indexName = indexName != null && indexName.trim().length() > 0 ? indexName : tableName + "_"
+						+ indexProperties.getPropertyName();
+				StringBuilder ddl = new StringBuilder();
+				ddl.append("\n");
+				ddl.append("CREATE INDEX ").append(indexName);
+				ddl.append("\n");
+				ddl.append("ON ").append(tableName).append(" (").append(indexProperties.getPropertyName())
+						.append(");\n");
+				indicesScripts.add(ddl.toString());
+			}
+		}
+		return indicesScripts;
+	}
+}

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableBuilder.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableBuilder.java
@@ -19,37 +19,30 @@ import static com.datastax.driver.core.DataType.Name.COUNTER;
 import static info.archinnov.achilles.internal.cql.TypeMapper.toCQLType;
 import static info.archinnov.achilles.internal.table.TableCreator.ACHILLES_DDL_SCRIPT;
 import static info.archinnov.achilles.internal.table.TableNameNormalizer.normalizerAndValidateColumnFamilyName;
-import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
-import info.archinnov.achilles.type.Pair;
-import info.archinnov.achilles.internal.validation.Validator;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TableBuilder {
+import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
+import info.archinnov.achilles.internal.validation.Validator;
+import info.archinnov.achilles.type.Pair;
+
+public class TableBuilder extends AbstractTableBuilder {
 
 	private static final Logger log = LoggerFactory.getLogger(ACHILLES_DDL_SCRIPT);
 
 	private String tableName;
 	private String comment;
-	private List<String> partitionComponents = new ArrayList<String>();
-	private List<String> clusteringComponents = new ArrayList<String>();
-	private Set<IndexProperties> indexedColumns = new HashSet<IndexProperties>();
-	private Map<String, String> columns = new LinkedHashMap<String, String>();
-	private Map<String, String> lists = new LinkedHashMap<String, String>();
-	private Map<String, String> sets = new LinkedHashMap<String, String>();
-	private Map<String, Pair<String, String>> maps = new LinkedHashMap<String, Pair<String, String>>();
+	private List<String> partitionComponents = new ArrayList<>();
+	private List<String> clusteringComponents = new ArrayList<>();
+	private Map<String, String> columns = new LinkedHashMap<>();
+	private Map<String, String> lists = new LinkedHashMap<>();
+	private Map<String, String> sets = new LinkedHashMap<>();
+	private Map<String, Pair<String, String>> maps = new LinkedHashMap<>();
 	private String reversedComponent = null;
 	private boolean counter;
 
@@ -235,27 +228,8 @@ public class TableBuilder {
 		return ddl.toString();
 	}
 
-	public boolean hasIndices() {
-		return indexedColumns.size() > 0;
-	}
-
 	public Collection<String> generateIndices() {
-		Collection<String> indicesScripts = new LinkedList<String>();
-		if (hasIndices()) {
-			for (IndexProperties indexProperties : indexedColumns) {
-				String indexName = indexProperties.getName();
-				indexName = indexName != null && indexName.trim().length() > 0 ? indexName : tableName + "_"
-						+ indexProperties.getPropertyName();
-				StringBuilder ddl = new StringBuilder();
-				ddl.append("\n");
-				ddl.append("CREATE INDEX ").append(indexName);
-				ddl.append("\n");
-				ddl.append("ON ").append(tableName).append(" (").append(indexProperties.getPropertyName())
-						.append(");\n");
-				indicesScripts.add(ddl.toString());
-			}
-		}
-		return indicesScripts;
+		return generateIndices(indexedColumns, tableName);
 	}
 
 	private String generateCounterTable() {

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableUpdateBuilder.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableUpdateBuilder.java
@@ -1,0 +1,109 @@
+package info.archinnov.achilles.internal.table;
+
+import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
+import info.archinnov.achilles.internal.metadata.holder.PropertyMeta;
+import info.archinnov.achilles.internal.metadata.holder.PropertyType;
+import info.archinnov.achilles.internal.validation.Validator;
+import info.archinnov.achilles.type.Pair;
+
+import java.util.*;
+
+import static info.archinnov.achilles.internal.cql.TypeMapper.toCQLType;
+
+public class TableUpdateBuilder extends AbstractTableBuilder {
+
+	private String tableName;
+	private Map<String, String> columns = new LinkedHashMap<>();
+	private Map<String, String> lists = new LinkedHashMap<>();
+	private Map<String, String> sets = new LinkedHashMap<>();
+	private Map<String, Pair<String, String>> maps = new LinkedHashMap<>();
+
+	public TableUpdateBuilder(String tableName) {
+		this.tableName = TableNameNormalizer.normalizerAndValidateColumnFamilyName(tableName);
+	}
+
+	public TableUpdateBuilder addColumn(String columnName, Class<?> javaType) {
+		columns.put(columnName, toCQLType(javaType).toString());
+		return this;
+	}
+
+	public TableUpdateBuilder addList(String listName, Class<?> javaValueType) {
+		lists.put(listName, toCQLType(javaValueType).toString());
+		return this;
+	}
+
+	public TableUpdateBuilder addSet(String setName, Class<?> javaValueType) {
+		sets.put(setName, toCQLType(javaValueType).toString());
+		return this;
+	}
+
+	public TableUpdateBuilder addMap(String mapName, Class<?> javaKeyType, Class<?> javaValueType) {
+		maps.put(mapName, Pair.create(toCQLType(javaKeyType).toString(), toCQLType(javaValueType).toString()));
+		return this;
+	}
+
+	public TableUpdateBuilder addIndex(IndexProperties indexProperties, PropertyMeta indexPropertyMeta) {
+		PropertyType type = indexPropertyMeta.type();
+		String name = indexProperties.getName();
+		Validator.validateFalse(type == PropertyType.LIST, "Index '%s' for table '%s' cannot be of list type", name,
+				tableName);
+		Validator.validateFalse(type == PropertyType.SET, "Index '%s' for table '%s' cannot be of set type", name,
+				tableName);
+		Validator.validateFalse(type == PropertyType.MAP, "Index '%s' for table '%s' cannot be of map type", name,
+				tableName);
+		Validator.validateFalse(indexPropertyMeta.isCounter(),
+				"Index '%s' for table '%s' cannot be set on a counter table", name, tableName);
+		indexedColumns.add(indexProperties);
+		return this;
+	}
+
+	public String generateDDLScript() {
+		StringBuilder ddl = new StringBuilder();
+
+		ddl.append("\n");
+
+		for (Map.Entry<String, String> columnEntry : columns.entrySet()) {
+			appendAlterStart(ddl);
+			ddl.append(columnEntry.getKey());
+			ddl.append(" ");
+			ddl.append(columnEntry.getValue());
+			ddl.append(";\n");
+		}
+		for (Map.Entry<String, String> listEntry : lists.entrySet()) {
+			appendAlterStart(ddl);
+			ddl.append(listEntry.getKey());
+			ddl.append(" list<");
+			ddl.append(listEntry.getValue());
+			ddl.append(">");
+			ddl.append(";\n");
+		}
+		for (Map.Entry<String, String> setEntry : sets.entrySet()) {
+			appendAlterStart(ddl);
+			ddl.append(setEntry.getKey());
+			ddl.append(" set<");
+			ddl.append(setEntry.getValue());
+			ddl.append(">");
+			ddl.append(";\n");
+		}
+		for (Map.Entry<String, Pair<String, String>> mapEntry : maps.entrySet()) {
+			appendAlterStart(ddl);
+			ddl.append(mapEntry.getKey());
+			ddl.append(" map<");
+			ddl.append(mapEntry.getValue().left);
+			ddl.append(",");
+			ddl.append(mapEntry.getValue().right);
+			ddl.append(">");
+			ddl.append(";\n");
+		}
+		return ddl.toString();
+	}
+
+	private void appendAlterStart(StringBuilder ddl) {
+		ddl.append("\tALTER TABLE ");
+		ddl.append(tableName).append(" ADD ");
+	}
+
+	public Collection<String> generateIndices() {
+		return super.generateIndices(indexedColumns, tableName);
+	}
+}

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableUpdater.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/table/TableUpdater.java
@@ -1,0 +1,126 @@
+package info.archinnov.achilles.internal.table;
+
+import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Maps;
+
+import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
+import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
+import info.archinnov.achilles.internal.metadata.holder.PropertyMeta;
+
+public class TableUpdater {
+	private static final Logger log = LoggerFactory.getLogger(TableUpdater.class);
+
+	public void updateTableForEntity(Session session, EntityMeta entityMeta, TableMetadata tableMetadata) {
+		log.debug("Updating table for entityMeta {}", entityMeta.getClassName());
+
+		if (!entityMeta.isSchemaUpdateEnabled()) {
+			return;
+		}
+
+		List<ColumnMetadata> existsColumns = tableMetadata.getColumns();
+		List<PropertyMeta> propertyMetas = entityMeta.getAllMetasExceptIdAndCounters();
+		Collection<String> namesCollection = Collections2.transform(existsColumns, new ColumnNameExtractFunction());
+		Set<String> columnNames = new HashSet<>(namesCollection);
+
+		TableUpdateBuilder builder = new TableUpdateBuilder(tableMetadata.getName());
+		addNewPropertiesToBuilder(propertyMetas, columnNames, builder);
+
+		addNewIndexesToBuilder(existsColumns, propertyMetas, builder);
+		session.execute(builder.generateDDLScript());
+		if (builder.hasIndices()) {
+			for (String indexScript : builder.generateIndices()) {
+				session.execute(indexScript);
+			}
+		}
+	}
+
+	private void addNewIndexesToBuilder(List<ColumnMetadata> existsColumns, List<PropertyMeta> propertyMetas,
+			TableUpdateBuilder builder) {
+		Collection<ColumnMetadata> columnsWithIndex = Collections2
+				.filter(existsColumns, new ColumnMetaIndexPredicate());
+		Collection<PropertyMeta> propertyWithIndex = Collections2.filter(propertyMetas,
+				new PropertyMetaIndexPredicate());
+		Collection<String> columnNamesWithIndex = Collections2.transform(columnsWithIndex,
+				new ColumnNameExtractFunction());
+		// name->indexed
+		Map<String, PropertyMeta> propertyMap = Maps.uniqueIndex(propertyWithIndex, new PropertyNameExtractFunction());
+		HashSet<String> newIndexes = new HashSet<>(columnNamesWithIndex);
+		newIndexes.removeAll(propertyMap.keySet());
+
+		for (String indexPropertyName : newIndexes) {
+			PropertyMeta meta = propertyMap.get(indexPropertyName);
+			IndexProperties indexProperties = meta.getIndexProperties();
+			builder.addIndex(new IndexProperties(indexProperties.getName(), indexPropertyName), meta);
+		}
+	}
+
+	private void addNewPropertiesToBuilder(List<PropertyMeta> propertyMetas, Set<String> columnNames,
+			TableUpdateBuilder builder) {
+		for (PropertyMeta propertyMeta : propertyMetas) {
+			if (!columnNames.contains(propertyMeta.getPropertyName())) {
+				String propertyName = propertyMeta.getPropertyName();
+				Class<?> keyClass = propertyMeta.getKeyClass();
+				Class<?> valueClass = propertyMeta.getValueClassForTableCreation();
+				switch (propertyMeta.type()) {
+				case SIMPLE:
+					builder.addColumn(propertyName, valueClass);
+					break;
+				case LIST:
+					builder.addList(propertyName, valueClass);
+					break;
+				case SET:
+					builder.addSet(propertyName, valueClass);
+					break;
+				case MAP:
+					builder.addMap(propertyName, keyClass, propertyMeta.getValueClass());
+					break;
+				default:
+					break;
+				}
+				if (propertyMeta.isIndexed()) {
+					IndexProperties indexProperties = new IndexProperties(propertyMeta.getIndexProperties().getName(),
+							propertyName);
+					builder.addIndex(indexProperties, propertyMeta);
+				}
+			}
+		}
+	}
+
+	private static class ColumnNameExtractFunction implements Function<ColumnMetadata, String> {
+		@Override
+		public String apply(ColumnMetadata columnMetadata) {
+			return columnMetadata.getName();
+		}
+	}
+
+	private static class PropertyNameExtractFunction implements Function<PropertyMeta, String> {
+		@Override
+		public String apply(PropertyMeta input) {
+			return input.getPropertyName();
+		}
+	}
+
+	private static class PropertyMetaIndexPredicate implements Predicate<PropertyMeta> {
+		@Override
+		public boolean apply(PropertyMeta input) {
+			return input.isIndexed();
+		}
+	}
+
+	private static class ColumnMetaIndexPredicate implements Predicate<ColumnMetadata> {
+		@Override
+		public boolean apply(ColumnMetadata input) {
+			return input.getIndex() != null;
+		}
+	}
+}

--- a/achilles-core/src/main/java/info/archinnov/achilles/persistence/PersistenceManagerFactory.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/persistence/PersistenceManagerFactory.java
@@ -26,6 +26,8 @@ import static info.archinnov.achilles.configuration.ConfigurationParameters.ENTI
 import static info.archinnov.achilles.configuration.ConfigurationParameters.EVENT_INTERCEPTORS;
 import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_BATCH_STATEMENTS_ORDERING;
 import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_TABLE_CREATION;
+import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_TABLE_UPDATE;
+import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_TABLE_UPDATE_MAP;
 import static info.archinnov.achilles.configuration.ConfigurationParameters.INSERT_STRATEGY;
 import static info.archinnov.achilles.configuration.ConfigurationParameters.KEYSPACE_NAME;
 import static info.archinnov.achilles.configuration.ConfigurationParameters.NATIVE_SESSION;
@@ -323,6 +325,30 @@ public class PersistenceManagerFactory {
             return this;
         }
 
+        /**
+         * Whether Achilles should force update table if entities have new fields and table not.
+         * This flag is useful for dev only. <strong>It
+         * should be disabled in production</strong>
+         *
+         * @return PersistenceManagerFactoryBuilder
+         */
+        public PersistenceManagerFactoryBuilder forceTableUpdate(boolean forceTableUpdate) {
+            configMap.put(FORCE_TABLE_UPDATE, forceTableUpdate);
+            return this;
+        }
+
+		/**
+		 * Map to allow table schema update, same as
+		 * {@link #forceTableUpdate(boolean)} per table. <strong>It should be
+		 * disabled in production</strong>
+		 * 
+		 * @return PersistenceManagerFactoryBuilder
+		 */
+        public PersistenceManagerFactoryBuilder withForceTableUpdateMap(Map<String,
+                Boolean> map) {
+            configMap.put(FORCE_TABLE_UPDATE_MAP, map);
+            return this;
+        }
 
         /**
          * Define the pre-configured {@code com.datastax.driver.core.Session} object to

--- a/achilles-core/src/test/java/info/archinnov/achilles/configuration/ArgumentExtractorTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/configuration/ArgumentExtractorTest.java
@@ -16,40 +16,16 @@
 package info.archinnov.achilles.configuration;
 
 import static info.archinnov.achilles.configuration.ArgumentExtractor.DEFAULT_LRU_CACHE_SIZE;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.BEAN_VALIDATION_ENABLE;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.BEAN_VALIDATION_VALIDATOR;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_READ_DEFAULT;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_READ_MAP;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_WRITE_DEFAULT;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.CONSISTENCY_LEVEL_WRITE_MAP;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.ENTITIES_LIST;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.ENTITY_PACKAGES;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.EVENT_INTERCEPTORS;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_BATCH_STATEMENTS_ORDERING;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.FORCE_TABLE_CREATION;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.INSERT_STRATEGY;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.KEYSPACE_NAME;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.NATIVE_SESSION;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.OBJECT_MAPPER;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.OBJECT_MAPPER_FACTORY;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.PREPARED_STATEMENTS_CACHE_SIZE;
-import static info.archinnov.achilles.configuration.ConfigurationParameters.PROXIES_WARM_UP_DISABLED;
-import static info.archinnov.achilles.type.ConsistencyLevel.ALL;
-import static info.archinnov.achilles.type.ConsistencyLevel.ANY;
-import static info.archinnov.achilles.type.ConsistencyLevel.LOCAL_QUORUM;
-import static info.archinnov.achilles.type.ConsistencyLevel.ONE;
+import static info.archinnov.achilles.configuration.ConfigurationParameters.*;
+import static info.archinnov.achilles.type.ConsistencyLevel.*;
 import static info.archinnov.achilles.type.InsertStrategy.ALL_FIELDS;
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
 import javax.validation.Validator;
+
 import org.hibernate.validator.internal.engine.ValidatorImpl;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -69,6 +46,7 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import info.archinnov.achilles.exception.AchillesException;
 import info.archinnov.achilles.interceptor.Interceptor;
 import info.archinnov.achilles.internal.bean.validation.FakeValidator;
@@ -204,6 +182,24 @@ public class ArgumentExtractorTest {
     }
 
     @Test
+	public void should_init_force_update() throws Exception {
+		configMap.put(FORCE_TABLE_UPDATE, true);
+
+		boolean actual = extractor.initForceTableUpdate(configMap);
+
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	public void should_init_default_force_update_to_false() throws Exception {
+		boolean actual = extractor.initForceTableUpdate(configMap);
+		Map<String, Boolean> map = extractor.initForceTableUpdateMap(configMap);
+
+		assertThat(actual).isFalse();
+		assertThat(map.isEmpty());
+	}
+
+	@Test
     public void should_init_object_mapper_factory() throws Exception {
         configMap.put(OBJECT_MAPPER_FACTORY, factory);
 

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/context/SchemaContextTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/context/SchemaContextTest.java
@@ -17,13 +17,13 @@
 package info.archinnov.achilles.internal.context;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,14 +31,17 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
+
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TableMetadata;
 import com.google.common.collect.Sets;
+
 import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
 import info.archinnov.achilles.internal.metadata.parsing.context.ParsingResult;
 import info.archinnov.achilles.internal.table.TableCreator;
+import info.archinnov.achilles.internal.table.TableUpdater;
 import info.archinnov.achilles.internal.table.TableValidator;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -58,6 +61,9 @@ public class SchemaContextTest {
     @Mock
     private TableCreator tableCreator;
 
+	@Mock
+	private TableUpdater tableUpdater;
+
     @Mock
     private TableValidator tableValidator;
 
@@ -68,7 +74,8 @@ public class SchemaContextTest {
     public void setUp() {
         context = new SchemaContext(true, session, keyspaceName, cluster, new ParsingResult(entityMetaMap, true));
         Whitebox.setInternalState(context, TableCreator.class, tableCreator);
-        Whitebox.setInternalState(context, TableValidator.class, tableValidator);
+		Whitebox.setInternalState(context, TableUpdater.class, tableUpdater);
+		Whitebox.setInternalState(context, TableValidator.class, tableValidator);
     }
 
     @Test
@@ -153,7 +160,20 @@ public class SchemaContextTest {
     }
 
     @Test
-    public void should_create_table_for_counter() throws Exception {
+	public void should_update_table_for_entity() throws Exception {
+		// Given
+		EntityMeta entityMeta = mock(EntityMeta.class);
+		TableMetadata tableMetadata = mock(TableMetadata.class);
+
+		// When
+		context.updateForEntity(entityMeta, tableMetadata);
+
+		// Then
+		verify(tableUpdater).updateTableForEntity(session, entityMeta, tableMetadata);
+	}
+
+	@Test
+	public void should_create_table_for_counter() throws Exception {
 
         // When
         context.createTableForCounter();

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapperTest.java
@@ -120,7 +120,7 @@ public class AchillesBootstrapperTest {
     }
 
     @Test
-    public void should_validate_tables() throws Exception {
+    public void should_validate_and_update_tables() throws Exception {
         // Given
         Map<Class<?>, EntityMeta> metas = ImmutableMap.<Class<?>, EntityMeta>of(UserBean.class, meta);
         Map<String, TableMetadata> tableMetaDatas = ImmutableMap.<String, TableMetadata>of("userbean", tableMeta);
@@ -135,6 +135,7 @@ public class AchillesBootstrapperTest {
 
         // Then
         verify(schemaContext).validateForEntity(meta, tableMeta);
+        verify(schemaContext).updateForEntity(meta, tableMeta);
     }
 
     @Test

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/parsing/EntityParserTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/parsing/EntityParserTest.java
@@ -20,6 +20,8 @@ import static info.archinnov.achilles.internal.metadata.holder.PropertyType.EMBE
 import static info.archinnov.achilles.internal.metadata.holder.PropertyType.ID;
 import static info.archinnov.achilles.internal.metadata.holder.PropertyType.SIMPLE;
 import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
@@ -80,6 +82,7 @@ public class EntityParserTest {
     public void setUp() {
         configContext.setDefaultReadConsistencyLevel(ConsistencyLevel.ONE);
         configContext.setDefaultWriteConsistencyLevel(ConsistencyLevel.ALL);
+        configContext.setForceColumnFamilyUpdateMap(new HashMap<String, Boolean>());
         configContext.setObjectMapperFactory(objectMapperFactory);
         configContext.setInsertStrategy(InsertStrategy.ALL_FIELDS);
     }
@@ -96,6 +99,7 @@ public class EntityParserTest {
         assertThat(meta.getIdMeta().getPropertyName()).isEqualTo("id");
         assertThat(meta.<Long>getIdClass()).isEqualTo(Long.class);
         assertThat(meta.getPropertyMetas()).hasSize(8);
+        assertThat(meta.isSchemaUpdateEnabled()).isFalse();
 
         PropertyMeta id = meta.getPropertyMetas().get("id");
         PropertyMeta name = meta.getPropertyMetas().get("name");

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/table/TableUpdaterTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/table/TableUpdaterTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2012-2014 DuyHai DOAN
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package info.archinnov.achilles.internal.table;
+
+import static info.archinnov.achilles.internal.metadata.holder.PropertyType.ID;
+import static info.archinnov.achilles.internal.metadata.holder.PropertyType.SIMPLE;
+import static java.util.Arrays.asList;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.internal.verification.Times;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+
+import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
+import info.archinnov.achilles.internal.metadata.holder.IndexProperties;
+import info.archinnov.achilles.internal.metadata.holder.PropertyMeta;
+import info.archinnov.achilles.test.builders.PropertyMetaTestBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TableUpdaterTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	private TableUpdater updater;
+
+	@Mock
+	private Session session;
+
+	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	private Cluster cluster;
+
+	@Mock
+	private KeyspaceMetadata keyspaceMeta;
+
+	@Mock
+	private TableMetadata tableMeta;
+
+	@Captor
+	private ArgumentCaptor<String> stringCaptor;
+
+	private String keyspaceName = "achilles";
+
+	private EntityMeta meta;
+
+	@Before
+	public void setUp() throws Exception {
+		when(cluster.getMetadata().getKeyspace(keyspaceName)).thenReturn(keyspaceMeta);
+		when(keyspaceMeta.getTables()).thenReturn(new ArrayList<TableMetadata>());
+		updater = new TableUpdater();
+        PropertyMeta idMeta = PropertyMetaTestBuilder.valueClass(Long.class).type(ID).field("id").build();
+
+        PropertyMeta longColPM = PropertyMetaTestBuilder.valueClass(Long.class).type(SIMPLE).field("longCol").build();
+        longColPM.setIndexProperties(new IndexProperties(""));
+
+        List<TableMetadata> tableMetas = asList(tableMeta);
+
+        // When
+        when(keyspaceMeta.getTables()).thenReturn(tableMetas);
+        when(tableMeta.getName()).thenReturn("tableName");
+
+        meta = new EntityMeta();
+        meta.setAllMetasExceptIdAndCounters(asList(longColPM));
+        meta.setIdMeta(idMeta);
+        meta.setTableName("tableName");
+        meta.setClassName("entityName");
+        meta.setSchemaUpdateEnabled(true);
+	}
+
+	@Test
+	public void should_update_table() throws Exception {
+
+		updater.updateTableForEntity(session, meta, tableMeta);
+
+        verify(session, new Times(2)).execute(stringCaptor.capture());
+
+        List<String> values = stringCaptor.getAllValues();
+        assertThat(values.get(0)).isEqualTo(
+                "\n\tALTER TABLE tableName ADD longCol bigint;\n");
+	}
+
+	@Test
+	public void should_create_indices_scripts() throws Exception {
+
+		updater.updateTableForEntity(session, meta, tableMeta);
+
+		verify(session, new Times(2)).execute(stringCaptor.capture());
+
+		assertThat(stringCaptor.getValue()).isEqualTo(
+				"\nCREATE INDEX tableName_longCol\n" + "ON tableName (longCol);\n");
+	}
+}


### PR DESCRIPTION
When new field added to already persisted entity type ORM will fail on first operation with this entity type. It is painful to manually correct table schema(e.g. ALTER) each time. 

Possibility to correct schema for newly added fields, if no columns with same name present, will be awesome.
