### PR TITLE
Fixes NPE when entity not managed

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/persistence/AbstractPersistenceManager.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/persistence/AbstractPersistenceManager.java
@@ -16,19 +16,6 @@
 
 package info.archinnov.achilles.persistence;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
-import static info.archinnov.achilles.internal.metadata.holder.EntityMeta.EntityState.MANAGED;
-import static info.archinnov.achilles.internal.metadata.holder.EntityMeta.EntityState.NOT_MANAGED;
-import static info.archinnov.achilles.type.OptionsBuilder.noOptions;
-import static info.archinnov.achilles.type.OptionsBuilder.withConsistency;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.Select;
@@ -51,6 +38,19 @@ import info.archinnov.achilles.query.typed.TypedQueryValidator;
 import info.archinnov.achilles.type.ConsistencyLevel;
 import info.archinnov.achilles.type.IndexCondition;
 import info.archinnov.achilles.type.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static info.archinnov.achilles.internal.metadata.holder.EntityMeta.EntityState.MANAGED;
+import static info.archinnov.achilles.internal.metadata.holder.EntityMeta.EntityState.NOT_MANAGED;
+import static info.archinnov.achilles.type.OptionsBuilder.noOptions;
+import static info.archinnov.achilles.type.OptionsBuilder.withConsistency;
 
 abstract class AbstractPersistenceManager {
 
@@ -163,6 +163,7 @@ abstract class AbstractPersistenceManager {
 
     protected <T> SliceQueryBuilder<T> sliceQuery(Class<T> entityClass) {
         EntityMeta meta = entityMetaMap.get(entityClass);
+        Validator.validateNotNull(meta, "The entity '%s' is not managed by achilles", entityClass.getName());
         Validator.validateTrue(meta.isClusteredEntity(),"Cannot perform slice query on entity type '%s' because it is " + "not a clustered entity",meta.getClassName());
         return new SliceQueryBuilder<>(sliceQueryExecutor, entityClass, meta);
     }

--- a/integration-test/src/test/java/info/archinnov/achilles/test/bugs/NPEWhenClassManaged.java
+++ b/integration-test/src/test/java/info/archinnov/achilles/test/bugs/NPEWhenClassManaged.java
@@ -1,0 +1,26 @@
+package info.archinnov.achilles.test.bugs;
+
+import info.archinnov.achilles.exception.AchillesException;
+import info.archinnov.achilles.junit.AchillesTestResource;
+import info.archinnov.achilles.persistence.PersistenceManager;
+import info.archinnov.achilles.test.integration.AchillesInternalCQLResource;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NPEWhenClassManaged {
+
+    @Rule
+    public AchillesInternalCQLResource resource = new AchillesInternalCQLResource(
+            AchillesTestResource.Steps.AFTER_TEST,
+            "CompleteBean",
+            "Tweet");
+
+    private PersistenceManager manager = resource.getPersistenceManager();
+
+    @Test(expected = AchillesException.class)
+    public void should_fail_instead_with_AchillesException_when_class_not_managed() {
+        manager.sliceQuery(NotManaged.class);
+    }
+
+    private static class NotManaged { }
+}


### PR DESCRIPTION
If one pass a class that is not managed by Achilles, when doing a `sliceQuery(...)` for example, Achilles throws an NPE : 

```
java.lang.NullPointerException
    at info.archinnov.achilles.persistence.AbstractPersistenceManager.sliceQuery(AbstractPersistenceManager.java:167)
    at info.archinnov.achilles.persistence.PersistenceManager.sliceQuery(PersistenceManager.java:467)
```

This PR, makes Achilles throw an `AchillesException` with a better exception message : 

```
info.archinnov.achilles.exception.AchillesException: The entity 'info.archinnov.achilles.test.bugs.NPEWhenClassManaged$NotManaged' is not managed by achilles
```
