### PR TITLE
Filter out finalize method interception

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityProxifier.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityProxifier.java
@@ -15,6 +15,19 @@
  */
 package info.archinnov.achilles.internal.persistence.operations;
 
+import info.archinnov.achilles.internal.context.facade.EntityOperations;
+import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
+import info.archinnov.achilles.internal.metadata.holder.PropertyMeta;
+import info.archinnov.achilles.internal.proxy.ProxyClassFactory;
+import info.archinnov.achilles.internal.proxy.ProxyInterceptor;
+import info.archinnov.achilles.internal.proxy.ProxyInterceptorBuilder;
+import info.archinnov.achilles.internal.reflection.ObjectInstantiator;
+import net.sf.cglib.proxy.Callback;
+import net.sf.cglib.proxy.Factory;
+import net.sf.cglib.proxy.NoOp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,18 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import info.archinnov.achilles.internal.proxy.ProxyInterceptorBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import info.archinnov.achilles.internal.context.facade.EntityOperations;
-import info.archinnov.achilles.internal.metadata.holder.EntityMeta;
-import info.archinnov.achilles.internal.metadata.holder.PropertyMeta;
-import info.archinnov.achilles.internal.proxy.ProxyInterceptor;
-import info.archinnov.achilles.internal.proxy.ProxyClassFactory;
-import info.archinnov.achilles.internal.reflection.ObjectInstantiator;
-import net.sf.cglib.proxy.Callback;
-import net.sf.cglib.proxy.Factory;
 
 public class EntityProxifier {
 
@@ -86,7 +87,10 @@ public class EntityProxifier {
             pm.forValues().setValueToField(entity,null);
         }
 
-        ((Factory) instance).setCallbacks(new Callback[] { buildInterceptor(context, entity, alreadyLoaded) });
+        ((Factory) instance).setCallbacks(new Callback[] {
+                buildInterceptor(context, entity, alreadyLoaded),
+                NoOp.INSTANCE
+        });
         return instance;
     }
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/proxy/ProxyClassFactory.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/proxy/ProxyClassFactory.java
@@ -16,12 +16,33 @@
 
 package info.archinnov.achilles.internal.proxy;
 
-import java.io.Serializable;
 import info.archinnov.achilles.internal.context.ConfigurationContext;
+import net.sf.cglib.proxy.CallbackFilter;
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.NoOp;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
 
 public class ProxyClassFactory {
+
+    private static final int NO_OP_CALLBACK_INDEX = 1;
+    private static final int METHOD_INTERCEPTOR_CALLBACK_INDEX = 0;
+    public static final Class[] CALLBACK_TYPES = new Class[] { MethodInterceptor.class, NoOp.class };
+    public static final CallbackFilter INTERCEPT_ALL_BUT_FINALIZE = new CallbackFilter() {
+        @Override
+        public int accept(Method method) {
+            return isFinalizeMethod(method) ? NO_OP_CALLBACK_INDEX : METHOD_INTERCEPTOR_CALLBACK_INDEX;
+        }
+
+        private boolean isFinalizeMethod(Method method) {
+            return method.getName().equals("finalize")
+                    && method.getReturnType().equals(Void.TYPE)
+                    && method.getParameterTypes().length == 0
+                    ;
+        }
+    };
 
     public Class<?> createProxyClass(Class<?> entityClass, ConfigurationContext configContext) {
         Enhancer enhancer = new Enhancer();
@@ -29,7 +50,8 @@ public class ProxyClassFactory {
         enhancer.setInterfaces(new Class[] { Serializable.class });
         enhancer.setClassLoader(configContext.selectClassLoader(entityClass));
         enhancer.setUseCache(true);
-        enhancer.setCallbackTypes(new Class[] { MethodInterceptor.class });
+        enhancer.setCallbackTypes(CALLBACK_TYPES);
+        enhancer.setCallbackFilter(INTERCEPT_ALL_BUT_FINALIZE);
         enhancer.setUseFactory(true);
         return enhancer.createClass();
     }

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/proxy/ProxyClassFactoryTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/proxy/ProxyClassFactoryTest.java
@@ -16,15 +16,17 @@
 
 package info.archinnov.achilles.internal.proxy;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import info.archinnov.achilles.internal.context.ConfigurationContext;
+import info.archinnov.achilles.test.mapping.entity.CompleteBean;
+import net.sf.cglib.proxy.Factory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import info.archinnov.achilles.internal.context.ConfigurationContext;
-import info.archinnov.achilles.test.mapping.entity.CompleteBean;
-import net.sf.cglib.proxy.Factory;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProxyClassFactoryTest {
@@ -54,5 +56,17 @@ public class ProxyClassFactoryTest {
 
         //Then
         assertThat(proxyClass1 == proxyClass2).isTrue();
+    }
+
+    @Test
+    public void should_not_intercept_finalize_methods() throws Exception {
+        Class<?> proxyClass = factory.createProxyClass(CompleteBean.class, new ConfigurationContext());
+
+        try {
+            proxyClass.getDeclaredMethod("finalize");
+            fail("Should have reported the finalize method don't exists");
+        } catch (NoSuchMethodException nsm) {
+            assertThat(nsm).hasMessageContaining("finalize");
+        }
     }
 }


### PR DESCRIPTION
Using `finalize` is usually considered a bad practice if not dangerous [[1]](http://howtodoinjava.com/2012/10/31/why-not-to-use-finalize-method-in-java/)[[2]](http://www.hboehm.info/misc_slides/java_finalizers.pdf). And a proxy for entity should not generate is own overriden `finalize` method for the sake of interception.

Also in debug mode, we have detected the Achilles proxies creates stress on the JVM Finalizer. (When the class is loaded the JVM will detect there's an overriden `finalize` method, and will queue the unreachable proxies for finalization)

EDIT : ~~Nonetheless if someone absolutely want Achilles to intercept finalize methods then a configuration toggle has been added.~~

I'm totally up for review and comment on this one.
