### PR TITLE
avoid intensive use of the executor

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/async/SynchronousTransformingFuture.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/async/SynchronousTransformingFuture.java
@@ -1,0 +1,82 @@
+package info.archinnov.achilles.async;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public class SynchronousTransformingFuture<I, O> implements ListenableFuture<O> {
+
+    private final Future<I> delegate;
+
+    private final Function<I, O> function;
+
+    /**
+     * As the value is created by transforming the underlying result, which may be mutable (e.g. a ResultSet will be consumed), we must cache the
+     * value once transformed.
+     */
+    private final ReentrantLock valueLock = new ReentrantLock();
+    private boolean valueAlreadyTransformed = false;
+    private O value;
+
+    public SynchronousTransformingFuture(Future<I> delegate, Function<I, O> function) {
+        this.delegate = delegate;
+        this.function = function;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return delegate.isDone();
+    }
+
+    @Override
+    public O get() throws InterruptedException, ExecutionException {
+        valueLock.lock();
+        if(valueAlreadyTransformed) {
+            return value;
+        }
+        try {
+            I i  = delegate.get();
+            value = function.apply(i);
+            valueAlreadyTransformed = true;
+            return value;
+        } finally {
+            valueLock.unlock();
+        }
+    }
+
+    @Override
+    public O get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        valueLock.lock();
+        if(valueAlreadyTransformed) {
+            return value;
+        }
+        try {
+            I i  = delegate.get(timeout, unit);
+            value = function.apply(i);
+            valueAlreadyTransformed = true;
+            return value;
+        } finally {
+            valueLock.unlock();
+        }
+    }
+
+    @Override
+    public void addListener(Runnable listener, Executor executor) {
+        executor.execute(listener);
+    }
+}

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/async/AsyncUtils.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/async/AsyncUtils.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import info.archinnov.achilles.async.SynchronousTransformingFuture;
 import info.archinnov.achilles.type.Empty;
 import org.apache.commons.lang3.ArrayUtils;
 import com.datastax.driver.core.ResultSet;
@@ -89,6 +90,10 @@ public class AsyncUtils {
 
     public <T, V> ListenableFuture<T> transformFuture(ListenableFuture<V> from, Function<V, T> function, ExecutorService executorService) {
         return Futures.transform(from, function, executorService);
+    }
+
+    public <T, V> ListenableFuture<T> transformFutureSync(ListenableFuture<V> from, Function<V, T> function) {
+        return new SynchronousTransformingFuture<>(from, function);
     }
 
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/context/DaoContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/context/DaoContext.java
@@ -147,7 +147,7 @@ public class DaoContext {
         log.debug("Load property '{}' for PersistenceContext '{}'", pm, context);
         PreparedStatement ps = cacheManager.getCacheForFieldSelect(session, dynamicPSCache, context, pm);
         final ListenableFuture<ResultSet> resultSetFuture = executeReadWithConsistency(context, ps, pm.structure().isStaticColumn());
-        final ListenableFuture<Row> futureRows = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        final ListenableFuture<Row> futureRows = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
         return asyncUtils.buildInterruptible(futureRows).getImmediately();
     }
 
@@ -196,7 +196,7 @@ public class DaoContext {
         PreparedStatement ps = counterQueryMap.get(SELECT);
         BoundStatementWrapper bsWrapper = binder.bindForSimpleCounterSelect(context, ps, counterMeta, consistencyLevel);
         final ListenableFuture<ResultSet> resultSetFuture = context.executeImmediate(bsWrapper);
-        final ListenableFuture<Row> futureRow = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        final ListenableFuture<Row> futureRow = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
         final Row row = asyncUtils.buildInterruptible(futureRow).getImmediately();
         return rowToLongFunction(ACHILLES_COUNTER_VALUE).apply(row);
     }
@@ -226,7 +226,7 @@ public class DaoContext {
         ConsistencyLevel consistencyLevel = overrider.getReadLevel(context);
         BoundStatementWrapper bsWrapper = binder.bindForClusteredCounterSelect(context, ps, false, consistencyLevel);
         final ListenableFuture<ResultSet> resultSetFuture = context.executeImmediate(bsWrapper);
-        return asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        return asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
     }
 
     public Long getClusteredCounterColumn(DaoOperations context, PropertyMeta counterMeta) {
@@ -238,7 +238,7 @@ public class DaoContext {
         BoundStatementWrapper bsWrapper = binder.bindForClusteredCounterSelect(context, ps, counterMeta.structure().isStaticColumn(), readLevel);
 
         final ListenableFuture<ResultSet> resultSetFuture = context.executeImmediate(bsWrapper);
-        final ListenableFuture<Row> futureRow = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        final ListenableFuture<Row> futureRow = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
         final Row row = asyncUtils.buildInterruptible(futureRow).getImmediately();
         return rowToLongFunction(cql3ColumnName).apply(row);
     }
@@ -259,7 +259,7 @@ public class DaoContext {
 		final EntityMeta entityMeta = context.getEntityMeta();
 
         final ListenableFuture<ResultSet> resultSetFuture = executeReadWithConsistency(context, ps, entityMeta.structure().hasOnlyStaticColumns());
-        return asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        return asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
     }
 
     public BoundStatementWrapper bindForSliceQuerySelect(SliceQueryProperties<?> sliceQueryProperties, ConsistencyLevel defaultReadConsistencyLevel) {

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/context/PersistenceContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/context/PersistenceContext.java
@@ -269,11 +269,11 @@ public class PersistenceContext {
                 }
             };
 
-            final ListenableFuture<T> triggersApplied = asyncUtils.transformFuture(resultSetFutures, applyTriggers, getExecutorService());
+            final ListenableFuture<T> triggersApplied = asyncUtils.transformFutureSync(resultSetFutures, applyTriggers);
 
             asyncUtils.maybeAddAsyncListeners(triggersApplied, options, getExecutorService());
 
-            final ListenableFuture<T> proxyCreated = asyncUtils.transformFuture(triggersApplied, createProxy, getExecutorService());
+            final ListenableFuture<T> proxyCreated = asyncUtils.transformFutureSync(triggersApplied, createProxy);
 
             return asyncUtils.buildInterruptible(proxyCreated);
         }
@@ -298,7 +298,7 @@ public class PersistenceContext {
                     return proxy;
                 }
             };
-            final ListenableFuture<T> triggersApplied = asyncUtils.transformFuture(resultSetFutures, applyTriggers, getExecutorService());
+            final ListenableFuture<T> triggersApplied = asyncUtils.transformFutureSync(resultSetFutures, applyTriggers);
             asyncUtils.maybeAddAsyncListeners(triggersApplied, options, getExecutorService());
             return asyncUtils.buildInterruptible(triggersApplied);
         }
@@ -314,7 +314,7 @@ public class PersistenceContext {
                     return (T) entity;
                 }
             };
-            final ListenableFuture<T> triggersApplied = asyncUtils.transformFuture(resultSetFutures, applyTriggers, getExecutorService());
+            final ListenableFuture<T> triggersApplied = asyncUtils.transformFutureSync(resultSetFutures, applyTriggers);
             asyncUtils.maybeAddAsyncListeners(triggersApplied, options, getExecutorService());
             return asyncUtils.buildInterruptible(triggersApplied);
         }
@@ -329,7 +329,7 @@ public class PersistenceContext {
                     return Empty.INSTANCE;
                 }
             };
-            final ListenableFuture<Empty> triggersApplied = asyncUtils.transformFuture(resultSetFutures, toEmpty, getExecutorService());
+            final ListenableFuture<Empty> triggersApplied = asyncUtils.transformFutureSync(resultSetFutures, toEmpty);
             asyncUtils.maybeAddAsyncListeners(triggersApplied, options, getExecutorService());
             return asyncUtils.buildInterruptible(triggersApplied);
         }
@@ -347,7 +347,7 @@ public class PersistenceContext {
                 }
             };
 
-            final ListenableFuture<T> triggersApplied = asyncUtils.transformFuture(achillesFuture, applyTrigger, getExecutorService());
+            final ListenableFuture<T> triggersApplied = asyncUtils.transformFutureSync(achillesFuture, applyTrigger);
 
             asyncUtils.maybeAddAsyncListeners(triggersApplied, options, getExecutorService());
 
@@ -358,7 +358,7 @@ public class PersistenceContext {
                 }
             };
 
-            final ListenableFuture<T> proxyCreated = asyncUtils.transformFuture(triggersApplied, createProxy, getExecutorService());
+            final ListenableFuture<T> proxyCreated = asyncUtils.transformFutureSync(triggersApplied, createProxy);
             return asyncUtils.buildInterruptible(proxyCreated);
         }
 
@@ -380,7 +380,7 @@ public class PersistenceContext {
                 }
             };
 
-            final ListenableFuture<T> proxyRemoved = asyncUtils.transformFuture(achillesFuture, removeProxy, getExecutorService());
+            final ListenableFuture<T> proxyRemoved = asyncUtils.transformFutureSync(achillesFuture, removeProxy);
 
             asyncUtils.maybeAddAsyncListeners(proxyRemoved, options, getExecutorService());
 
@@ -392,7 +392,7 @@ public class PersistenceContext {
                 }
             };
 
-            final ListenableFuture<T> triggersApplied = asyncUtils.transformFuture(achillesFuture, applyTriggers, getExecutorService());
+            final ListenableFuture<T> triggersApplied = asyncUtils.transformFutureSync(achillesFuture, applyTriggers);
 
             return asyncUtils.buildInterruptible(triggersApplied);
         }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/CounterLoader.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/CounterLoader.java
@@ -53,7 +53,7 @@ public class CounterLoader {
                 return entity;
             }
         };
-        final ListenableFuture<T> futureEntity = asyncUtils.transformFuture(futureRow, rowToEntity, context.getExecutorService());
+        final ListenableFuture<T> futureEntity = asyncUtils.transformFutureSync(futureRow, rowToEntity);
         return asyncUtils.buildInterruptible(futureEntity);
     }
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityLoader.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityLoader.java
@@ -61,7 +61,7 @@ public class EntityLoader {
                     return entity;
                 }
             };
-            final ListenableFuture<T> futureEntity = asyncUtils.transformFuture(futureRow, rowToEntity, context.getExecutorService());
+            final ListenableFuture<T> futureEntity = asyncUtils.transformFutureSync(futureRow, rowToEntity);
             achillesFuture = asyncUtils.buildInterruptible(futureEntity);
         }
         return achillesFuture;

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityRefresher.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/EntityRefresher.java
@@ -46,7 +46,7 @@ public class EntityRefresher {
         final AchillesFuture<T> entityFuture = loader.load(context, entityClass);
 
         Function<T, T> updateInterceptor = updateProxyInterceptor(context, interceptor, entity, primaryKey);
-        final ListenableFuture<T> triggerInterceptors = asyncUtils.transformFuture(entityFuture, updateInterceptor, context.getExecutorService());
+        final ListenableFuture<T> triggerInterceptors = asyncUtils.transformFutureSync(entityFuture, updateInterceptor);
         return asyncUtils.buildInterruptible(triggerInterceptors);
     }
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/SliceQueryExecutor.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/SliceQueryExecutor.java
@@ -88,7 +88,7 @@ public class SliceQueryExecutor {
         };
 
         final ListenableFuture<List<T>> futureEntities = coreAsyncGet(sliceQueryProperties);
-        final ListenableFuture<T> futureEntity = asyncUtils.transformFuture(futureEntities, takeFirstFunction, executorService);
+        final ListenableFuture<T> futureEntity = asyncUtils.transformFutureSync(futureEntities, takeFirstFunction);
         return asyncUtils.buildInterruptible(futureEntity);
     }
 
@@ -98,7 +98,7 @@ public class SliceQueryExecutor {
         final BoundStatementWrapper bsWrapper = daoContext.bindForSliceQuerySelect(sliceQueryProperties, defaultReadLevel);
 
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(bsWrapper);
-        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROWS, executorService);
+        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROWS);
         Function<List<Row>, List<T>> rowsToEntities = new Function<List<Row>, List<T>>() {
             @Override
             public List<T> apply(List<Row> rows) {
@@ -112,10 +112,10 @@ public class SliceQueryExecutor {
                 return clusteredEntities;
             }
         };
-        final ListenableFuture<List<T>> futureEntities = asyncUtils.transformFuture(futureRows, rowsToEntities, executorService);
+        final ListenableFuture<List<T>> futureEntities = asyncUtils.transformFutureSync(futureRows, rowsToEntities);
         asyncUtils.maybeAddAsyncListeners(futureEntities, sliceQueryProperties.getAsyncListeners(), executorService);
 
-        return asyncUtils.transformFuture(futureEntities, this.<T>getProxyListTransformer(), executorService);
+        return asyncUtils.transformFutureSync(futureEntities, this.<T>getProxyListTransformer());
     }
 
     public <T> Iterator<T> iterator(final SliceQueryProperties<T> sliceQueryProperties) {
@@ -127,7 +127,7 @@ public class SliceQueryExecutor {
         log.debug("Get iterator for slice query asynchronously");
         final BoundStatementWrapper bsWrapper = daoContext.bindForSliceQuerySelect(sliceQueryProperties, defaultReadLevel);
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(bsWrapper);
-        final ListenableFuture<Iterator<Row>> futureIterator = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ITERATOR, executorService);
+        final ListenableFuture<Iterator<Row>> futureIterator = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ITERATOR);
 
         Function<Iterator<Row>, Iterator<T>> rowToIterator = new Function<Iterator<Row>, Iterator<T>>() {
             @Override
@@ -136,7 +136,7 @@ public class SliceQueryExecutor {
                 return new SliceQueryIterator<>(sliceQueryProperties, context, rowIterator);
             }
         };
-        final ListenableFuture<Iterator<T>> listenableFuture = asyncUtils.transformFuture(futureIterator, rowToIterator, executorService);
+        final ListenableFuture<Iterator<T>> listenableFuture = asyncUtils.transformFutureSync(futureIterator, rowToIterator);
         asyncUtils.maybeAddAsyncListeners(listenableFuture, sliceQueryProperties.getAsyncListeners(), executorService);
         return asyncUtils.buildInterruptible(listenableFuture);
     }

--- a/achilles-core/src/main/java/info/archinnov/achilles/query/cql/NativeQuery.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/query/cql/NativeQuery.java
@@ -96,7 +96,7 @@ public class NativeQuery {
 
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(nativeStatementWrapper);
 
-        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROWS, executorService);
+        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROWS);
 
         Function<List<Row>, List<TypedMap>> rowsToTypedMaps = new Function<List<Row>, List<TypedMap>>() {
             @Override
@@ -105,7 +105,7 @@ public class NativeQuery {
             }
         };
 
-        final ListenableFuture<List<TypedMap>> futureTypedMap = asyncUtils.transformFuture(futureRows, rowsToTypedMaps, executorService);
+        final ListenableFuture<List<TypedMap>> futureTypedMap = asyncUtils.transformFutureSync(futureRows, rowsToTypedMaps);
 
         asyncUtils.maybeAddAsyncListeners(futureTypedMap, asyncListeners, executorService);
 
@@ -134,7 +134,7 @@ public class NativeQuery {
     public AchillesFuture<TypedMap> asyncFirst(FutureCallback<Object>... asyncListeners) {
         log.debug("Get first result for native query '{}' asynchronously", nativeStatementWrapper.getStatement());
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(nativeStatementWrapper);
-        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROWS, executorService);
+        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROWS);
 
         Function<List<Row>, TypedMap> rowsToTypedMap = new Function<List<Row>, TypedMap>() {
             @Override
@@ -147,7 +147,7 @@ public class NativeQuery {
                 }
             }
         };
-        final ListenableFuture<TypedMap> futureTypedMap = asyncUtils.transformFuture(futureRows, rowsToTypedMap, executorService);
+        final ListenableFuture<TypedMap> futureTypedMap = asyncUtils.transformFutureSync(futureRows, rowsToTypedMap);
 
         asyncUtils.maybeAddAsyncListeners(futureTypedMap, asyncListeners, executorService);
 
@@ -201,7 +201,7 @@ public class NativeQuery {
             }
         };
 
-        final ListenableFuture<Iterator<TypedMap>> futureTypedMapIterator = asyncUtils.transformFuture(futureResultSet, toTypedMap, executorService);
+        final ListenableFuture<Iterator<TypedMap>> futureTypedMapIterator = asyncUtils.transformFutureSync(futureResultSet, toTypedMap);
         return asyncUtils.buildInterruptible(futureTypedMapIterator);
     }
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/query/typed/TypedQuery.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/query/typed/TypedQuery.java
@@ -110,18 +110,18 @@ public class TypedQuery<T> {
         log.debug("Get results asynchronously for typed query '{}'", nativeStatementWrapper.getStatement());
 
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(nativeStatementWrapper);
-        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROWS, executorService);
+        final ListenableFuture<List<Row>> futureRows = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROWS);
 
         Function<List<Row>, List<T>> rowsToEntities = rowsToEntities();
         Function<List<T>, List<T>> applyTriggers = applyTriggersToEntities();
         Function<List<T>, List<T>> maybeCreateProxy = proxifyEntities();
 
-        final ListenableFuture<List<T>> rawEntities = asyncUtils.transformFuture(futureRows, rowsToEntities, executorService);
-        final ListenableFuture<List<T>> entitiesWithTriggers = asyncUtils.transformFuture(rawEntities, applyTriggers, executorService);
+        final ListenableFuture<List<T>> rawEntities = asyncUtils.transformFutureSync(futureRows, rowsToEntities);
+        final ListenableFuture<List<T>> entitiesWithTriggers = asyncUtils.transformFutureSync(rawEntities, applyTriggers);
 
         asyncUtils.maybeAddAsyncListeners(entitiesWithTriggers, asyncListeners, executorService);
 
-        final ListenableFuture<List<T>> maybeProxyCreated = asyncUtils.transformFuture(entitiesWithTriggers, maybeCreateProxy, executorService);
+        final ListenableFuture<List<T>> maybeProxyCreated = asyncUtils.transformFutureSync(entitiesWithTriggers, maybeCreateProxy);
 
         return asyncUtils.buildInterruptible(maybeProxyCreated);
     }
@@ -154,18 +154,18 @@ public class TypedQuery<T> {
         log.debug("Get first result asynchronously for typed query '{}'", nativeStatementWrapper.getStatement());
 
         final ListenableFuture<ResultSet> resultSetFuture = daoContext.execute(nativeStatementWrapper);
-        final ListenableFuture<Row> futureRow = asyncUtils.transformFuture(resultSetFuture, RESULTSET_TO_ROW, executorService);
+        final ListenableFuture<Row> futureRow = asyncUtils.transformFutureSync(resultSetFuture, RESULTSET_TO_ROW);
 
         Function<Row, T> rowToEntity = rowToEntity();
         Function<T, T> applyTriggers = applyTriggersToEntity();
         Function<T, T> maybeCreateProxy = proxifyEntity();
 
-        final ListenableFuture<T> rawEntity = asyncUtils.transformFuture(futureRow, rowToEntity, executorService);
-        final ListenableFuture<T> entityWithTriggers = asyncUtils.transformFuture(rawEntity, applyTriggers, executorService);
+        final ListenableFuture<T> rawEntity = asyncUtils.transformFutureSync(futureRow, rowToEntity);
+        final ListenableFuture<T> entityWithTriggers = asyncUtils.transformFutureSync(rawEntity, applyTriggers);
 
         asyncUtils.maybeAddAsyncListeners(entityWithTriggers, asyncListeners, executorService);
 
-        final ListenableFuture<T> maybeProxyCreated = asyncUtils.transformFuture(entityWithTriggers, maybeCreateProxy, executorService);
+        final ListenableFuture<T> maybeProxyCreated = asyncUtils.transformFutureSync(entityWithTriggers, maybeCreateProxy);
 
         return asyncUtils.buildInterruptible(maybeProxyCreated);
     }

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/context/DaoContextTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/context/DaoContextTest.java
@@ -348,7 +348,7 @@ public class DaoContextTest {
         when(overrider.getReadLevel(context)).thenReturn(LOCAL_QUORUM);
         when(binder.bindStatementWithOnlyPKInWhereClause(context, ps, false, LOCAL_QUORUM)).thenReturn(bsWrapper);
         when(context.executeImmediate(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
 
         // When
         final ListenableFuture<Row> actual = daoContext.loadEntity(context);
@@ -369,7 +369,7 @@ public class DaoContextTest {
         when(overrider.getReadLevel(context)).thenReturn(EACH_QUORUM);
         when(binder.bindStatementWithOnlyPKInWhereClause(context, ps, true, EACH_QUORUM)).thenReturn(bsWrapper);
         when(context.executeImmediate(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
         when(asyncUtils.buildInterruptible(futureRow).getImmediately()).thenReturn(row);
 
         // When
@@ -450,7 +450,7 @@ public class DaoContextTest {
         when(counterQueryMap.get(CQLQueryType.SELECT)).thenReturn(ps);
         when(binder.bindForSimpleCounterSelect(context, ps, pm, EACH_QUORUM)).thenReturn(bsWrapper);
         when(context.executeImmediate(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
         when(asyncUtils.buildInterruptible(futureRow).getImmediately()).thenReturn(row);
         when(row.isNull(ACHILLES_COUNTER_VALUE)).thenReturn(false);
         when(row.getLong(ACHILLES_COUNTER_VALUE)).thenReturn(11L);
@@ -506,7 +506,7 @@ public class DaoContextTest {
         when(overrider.getReadLevel(context)).thenReturn(EACH_QUORUM);
         when(binder.bindForClusteredCounterSelect(context, ps, false, EACH_QUORUM)).thenReturn(bsWrapper);
         when(context.executeImmediate(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
 
         // When
         ListenableFuture<Row> actual = daoContext.getClusteredCounter(context);
@@ -527,7 +527,7 @@ public class DaoContextTest {
         when(overrider.getReadLevel(context, counterMeta)).thenReturn(EACH_QUORUM);
         when(binder.bindForClusteredCounterSelect(context, ps, true, EACH_QUORUM)).thenReturn(bsWrapper);
         when(context.executeImmediate(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
         when(asyncUtils.buildInterruptible(futureRow).getImmediately()).thenReturn(row);
 
         when(row.isNull("counter")).thenReturn(false);

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/context/PersistenceManagerFacadeTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/context/PersistenceManagerFacadeTest.java
@@ -162,8 +162,8 @@ public class PersistenceManagerFacadeTest {
     public void should_persist() throws Exception {
         //Given
         when(proxifier.buildProxyWithAllFieldsLoadedExceptCounters(entity, context.entityFacade)).thenReturn(entity);
-        when(asyncUtils.transformFuture(eq(futureResultSets), resultSetsToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
-        when(asyncUtils.transformFuture(eq(futureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureResultSets), resultSetsToEntityCaptor.capture())).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         //When
@@ -210,7 +210,7 @@ public class PersistenceManagerFacadeTest {
     @Test
     public void should_update() throws Exception {
         //Given
-        when(asyncUtils.transformFuture(eq(futureResultSets), resultSetsToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureResultSets), resultSetsToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         //When
@@ -232,7 +232,7 @@ public class PersistenceManagerFacadeTest {
     @Test
     public void should_delete() throws Exception {
         //Given
-        when(asyncUtils.transformFuture(eq(futureResultSets), resultSetsToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureResultSets), resultSetsToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         //When
@@ -257,8 +257,8 @@ public class PersistenceManagerFacadeTest {
         when(loader.load(context.entityFacade, CompleteBean.class)).thenReturn(achillesFutureEntity);
         when(proxifier.buildProxyWithAllFieldsLoadedExceptCounters(entity, context.entityFacade)).thenReturn(entity);
 
-        when(asyncUtils.transformFuture(eq(achillesFutureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
-        when(asyncUtils.transformFuture(eq(futureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(achillesFutureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         //When
@@ -299,8 +299,8 @@ public class PersistenceManagerFacadeTest {
         CompleteBean proxy = new CompleteBean();
         when(refresher.refresh(proxy, context.entityFacade)).thenReturn(achillesFutureEntity);
         when(proxifier.removeProxy(proxy)).thenReturn(entity);
-        when(asyncUtils.transformFuture(eq(achillesFutureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
-        when(asyncUtils.transformFuture(eq(futureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(achillesFutureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         // When

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/CounterLoaderTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/CounterLoaderTest.java
@@ -107,7 +107,7 @@ public class CounterLoaderTest {
     public void should_load_clustered_counters() throws Exception {
         // Given
         Row row = mock(Row.class);
-        when(asyncUtils.transformFuture(eq(futureRow), rowToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureRow), rowToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         when(overrider.getReadLevel(context)).thenReturn(ONE);
@@ -130,7 +130,7 @@ public class CounterLoaderTest {
     @Test
     public void should_not_load_clustered_counters_when_not_found() throws Exception {
         // Given
-        when(asyncUtils.transformFuture(eq(futureRow), rowToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureRow), rowToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         when(overrider.getReadLevel(context)).thenReturn(ONE);

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/EntityLoaderTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/EntityLoaderTest.java
@@ -117,7 +117,7 @@ public class EntityLoaderTest {
         when(meta.structure().isClusteredCounter()).thenReturn(false);
         when(context.loadEntity()).thenReturn(futureRow);
         when(meta.forOperations().instanciate()).thenReturn(entity);
-        when(asyncUtils.transformFuture(eq(futureRow), rowToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureRow), rowToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         // When
@@ -139,7 +139,7 @@ public class EntityLoaderTest {
         // Given
         when(meta.structure().isClusteredCounter()).thenReturn(false);
         when(context.loadEntity()).thenReturn(futureRow);
-        when(asyncUtils.transformFuture(eq(futureRow), rowToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureRow), rowToEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFutureEntity);
 
         // When

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/EntityRefresherTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/EntityRefresherTest.java
@@ -110,7 +110,7 @@ public class EntityRefresherTest {
         when(context.getEntityMeta()).thenReturn(entityMeta);
         when(loader.load(context, CompleteBean.class)).thenReturn(achillesFutureEntity);
         when(context.getAllGettersExceptCounters()).thenReturn(allGettersExceptCounters);
-        when(asyncUtils.transformFuture(eq(achillesFutureEntity), interceptorCaptor.capture(), eq(executorService))).thenReturn(achillesFutureEntity);
+        when(asyncUtils.transformFutureSync(eq(achillesFutureEntity), interceptorCaptor.capture())).thenReturn(achillesFutureEntity);
         when(asyncUtils.buildInterruptible(achillesFutureEntity)).thenReturn(achillesFutureEntity);
 
         // When

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/SliceQueryExecutorTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/persistence/operations/SliceQueryExecutorTest.java
@@ -187,9 +187,9 @@ public class SliceQueryExecutorTest {
         when(daoContext.bindForSliceQuerySelect(sliceQueryProperties, defaultReadLevel)).thenReturn(bsWrapper);
 
         when(daoContext.execute(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROWS, executorService)).thenReturn(futureRows);
-        when(asyncUtils.transformFuture(eq(futureRows), rowsToEntitiesCaptor.capture(), eq(executorService))).thenReturn(futureEntities);
-        when(asyncUtils.transformFuture(eq(futureEntities), isoEntitiesCaptor.capture(), eq(executorService))).thenReturn(futureEntities);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROWS)).thenReturn(futureRows);
+        when(asyncUtils.transformFutureSync(eq(futureRows), rowsToEntitiesCaptor.capture())).thenReturn(futureEntities);
+        when(asyncUtils.transformFutureSync(eq(futureEntities), isoEntitiesCaptor.capture())).thenReturn(futureEntities);
         when(asyncUtils.buildInterruptible(futureEntities)).thenReturn(achillesFutureEntities);
 
         when(meta.forOperations().instanciate()).thenReturn(entity);
@@ -220,8 +220,8 @@ public class SliceQueryExecutorTest {
         when(daoContext.bindForSliceQuerySelect(sliceQueryProperties, defaultReadLevel)).thenReturn(bsWrapper);
 
         when(daoContext.execute(bsWrapper)).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ITERATOR, executorService)).thenReturn(futureIteratorRow);
-        when(asyncUtils.transformFuture(eq(futureIteratorRow), rowToEntityIteratorCaptor.capture(), eq(executorService))).thenReturn(futureIteratorEntities);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ITERATOR)).thenReturn(futureIteratorRow);
+        when(asyncUtils.transformFutureSync(eq(futureIteratorRow), rowToEntityIteratorCaptor.capture())).thenReturn(futureIteratorEntities);
         when(asyncUtils.buildInterruptible(futureIteratorEntities)).thenReturn(achillesFutureIteratorEntities);
 
         when(contextFactory.newContextForSliceQuery(ClusteredEntity.class, partitionComponents, LOCAL_QUORUM)).thenReturn(context);

--- a/achilles-core/src/test/java/info/archinnov/achilles/query/cql/NativeQueryTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/query/cql/NativeQueryTest.java
@@ -137,8 +137,8 @@ public class NativeQueryTest {
         List<TypedMap> typedMaps = new ArrayList<>();
 
         when(daoContext.execute(any(NativeStatementWrapper.class))).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROWS, executorService)).thenReturn(futureRows);
-        when(asyncUtils.transformFuture(eq(futureRows), rowsToTypedMapsCaptor.capture(), eq(executorService))).thenReturn(futureTypedMaps);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROWS)).thenReturn(futureRows);
+        when(asyncUtils.transformFutureSync(eq(futureRows), rowsToTypedMapsCaptor.capture())).thenReturn(futureTypedMaps);
         when(asyncUtils.buildInterruptible(futureTypedMaps)).thenReturn(achillesFutureTypedMaps);
 
         when(mapper.mapRows(rows)).thenReturn(typedMaps);
@@ -165,8 +165,8 @@ public class NativeQueryTest {
         typedMaps.add(typedMap);
 
         when(daoContext.execute(any(NativeStatementWrapper.class))).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROWS, executorService)).thenReturn(futureRows);
-        when(asyncUtils.transformFuture(eq(futureRows), rowsToTypedMapCaptor.capture(), eq(executorService))).thenReturn(futureTypedMap);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROWS)).thenReturn(futureRows);
+        when(asyncUtils.transformFutureSync(eq(futureRows), rowsToTypedMapCaptor.capture())).thenReturn(futureTypedMap);
         when(asyncUtils.buildInterruptible(futureTypedMap)).thenReturn(achillesFutureTypedMap);
 
         when(mapper.mapRows(rows)).thenReturn(typedMaps);
@@ -191,8 +191,8 @@ public class NativeQueryTest {
         List<TypedMap> typedMaps = new ArrayList<>();
 
         when(daoContext.execute(any(NativeStatementWrapper.class))).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROWS, executorService)).thenReturn(futureRows);
-        when(asyncUtils.transformFuture(eq(futureRows), rowsToTypedMapCaptor.capture(), eq(executorService))).thenReturn(futureTypedMap);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROWS)).thenReturn(futureRows);
+        when(asyncUtils.transformFutureSync(eq(futureRows), rowsToTypedMapCaptor.capture())).thenReturn(futureTypedMap);
         when(asyncUtils.buildInterruptible(futureTypedMap)).thenReturn(achillesFutureTypedMap);
 
         when(mapper.mapRows(rows)).thenReturn(typedMaps);
@@ -262,7 +262,7 @@ public class NativeQueryTest {
         Iterator<TypedMap> typedMapIterator = mock(TypedMapIterator.class);
 
         when(daoContext.execute(nativeStatementCaptor.capture())).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(eq(futureResultSet), any(Function.class), eq(executorService))).thenReturn(futureTypedMapIterator);
+        when(asyncUtils.transformFutureSync(eq(futureResultSet), any(Function.class))).thenReturn(futureTypedMapIterator);
         when(asyncUtils.buildInterruptible(futureTypedMapIterator)).thenReturn(achillesFuture);
 
         when(achillesFuture.get()).thenReturn(typedMapIterator);

--- a/achilles-core/src/test/java/info/archinnov/achilles/query/typed/TypedQueryTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/query/typed/TypedQueryTest.java
@@ -163,9 +163,9 @@ public class TypedQueryTest {
         initBuilder(statement, meta, meta.getPropertyMetas(), MANAGED);
 
         when(daoContext.execute(any(AbstractStatementWrapper.class))).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROWS, executorService)).thenReturn(futureRows);
-        when(asyncUtils.transformFuture(eq(futureRows), rowsToEntitiesCaptor.capture(), eq(executorService))).thenReturn(futureEntities);
-        when(asyncUtils.transformFuture(eq(futureEntities), isoEntitiesCaptor.capture(), eq(executorService))).thenReturn(futureEntities);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROWS)).thenReturn(futureRows);
+        when(asyncUtils.transformFutureSync(eq(futureRows), rowsToEntitiesCaptor.capture())).thenReturn(futureEntities);
+        when(asyncUtils.transformFutureSync(eq(futureEntities), isoEntitiesCaptor.capture())).thenReturn(futureEntities);
         when(asyncUtils.buildInterruptible(futureEntities)).thenReturn(achillesFuturesEntities);
 
         when(mapper.mapRowToEntityWithPrimaryKey(eq(meta), eq(row), Mockito.<Map<String, PropertyMeta>>any(), eq(MANAGED))).thenReturn(entity);
@@ -209,9 +209,9 @@ public class TypedQueryTest {
         initBuilder(statement, meta, meta.getPropertyMetas(), MANAGED);
 
         when(daoContext.execute(any(AbstractStatementWrapper.class))).thenReturn(futureResultSet);
-        when(asyncUtils.transformFuture(futureResultSet, RESULTSET_TO_ROW, executorService)).thenReturn(futureRow);
-        when(asyncUtils.transformFuture(eq(futureRow), rowToEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
-        when(asyncUtils.transformFuture(eq(futureEntity), isoEntityCaptor.capture(), eq(executorService))).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(futureResultSet, RESULTSET_TO_ROW)).thenReturn(futureRow);
+        when(asyncUtils.transformFutureSync(eq(futureRow), rowToEntityCaptor.capture())).thenReturn(futureEntity);
+        when(asyncUtils.transformFutureSync(eq(futureEntity), isoEntityCaptor.capture())).thenReturn(futureEntity);
         when(asyncUtils.buildInterruptible(futureEntity)).thenReturn(achillesFuturesEntity);
 
         when(mapper.mapRowToEntityWithPrimaryKey(eq(meta), eq(row), Mockito.<Map<String, PropertyMeta>>any(), eq(MANAGED))).thenReturn(entity);

--- a/integration-test/src/test/java/info/archinnov/achilles/test/integration/tests/AsyncOperationsIT.java
+++ b/integration-test/src/test/java/info/archinnov/achilles/test/integration/tests/AsyncOperationsIT.java
@@ -18,6 +18,8 @@ package info.archinnov.achilles.test.integration.tests;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static info.archinnov.achilles.listener.CASResultListener.CASResult;
 import static info.archinnov.achilles.type.OptionsBuilder.withAsyncListeners;
+import static java.lang.Long.MAX_VALUE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.fest.assertions.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Map;
@@ -244,7 +246,7 @@ public class AsyncOperationsIT {
         FutureCallback<Object> successCallBack = new FutureCallback<Object>() {
             @Override
             public void onSuccess(Object result) {
-                successSpy.getAndSet(result);
+                successSpy.set(result);
                 latch.countDown();
             }
 


### PR DESCRIPTION
This pull requests void using too much the executor to process trivial operation like mapping rows, wrap in a proxy etc.

For now I will suggest against merging this PR as one issue remains. With the design I propose, all transformations and triggers are performed when get() is called on the future.
In sync mode it is ok as the PersistenceManager performs a get() on the future before returning.
In async mode, for find-like method, it should be ok as the client will want to get the result, but for insert, it can be an issue, because  the client may not call get() on the future, and then post insert interceptors won't be called.
Maybe using the executor in async mode to perform the get() one the future to ensure that interceptors are called would be almost ok. One new issue would be that with the current code one thread per future is required as some operation may take a lot longer than others. A solution is to wrap the executor in a CompletionService, that is a Queue-like structure for Futures but instead of being FIFO, it returns the Future when they are done.