### PR TITLE
Fixing issue with Achilles counter

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/context/SchemaContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/context/SchemaContext.java
@@ -13,8 +13,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package info.archinnov.achilles.internal.context;
+
+import static info.archinnov.achilles.counter.AchillesCounter.ACHILLES_COUNTER_TABLE;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,6 +31,7 @@ import info.archinnov.achilles.internal.table.TableUpdater;
 import info.archinnov.achilles.internal.table.TableValidator;
 
 public class SchemaContext {
+
     private ConfigurationContext configContext;
 
     private Cluster cluster;
@@ -90,5 +92,9 @@ public class SchemaContext {
 
     public void updateForEntity(EntityMeta entityMeta, TableMetadata tableMetaData) {
         tableUpdater.updateTableForEntity(session, entityMeta, tableMetaData);
+    }
+
+    public boolean achillesCounterTableExists() {
+        return cluster.getMetadata().getKeyspace(keyspaceName).getTable(ACHILLES_COUNTER_TABLE) != null;
     }
 }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapper.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapper.java
@@ -16,7 +16,6 @@
 
 package info.archinnov.achilles.internal.metadata.discovery;
 
-import static info.archinnov.achilles.counter.AchillesCounter.ACHILLES_COUNTER_TABLE;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,15 +82,15 @@ public class AchillesBootstrapper {
             }
         }
 
-        if (schemaContext.hasSimpleCounter()) {
-            if (tableMetaDatas.containsKey(ACHILLES_COUNTER_TABLE)) {
+        if (schemaContext.hasSimpleCounter()) {            
+            if (schemaContext.achillesCounterTableExists()) {
                 schemaContext.validateAchillesCounter();
             } else {
                 schemaContext.createTableForCounter();
             }
         }
     }
-
+    
     public DaoContext buildDaoContext(Session session, ParsingResult parsingResult,
             ConfigurationContext configContext) {
         log.debug("Build DaoContext");

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/metadata/discovery/AchillesBootstrapperTest.java
@@ -177,6 +177,7 @@ public class AchillesBootstrapperTest {
         when(meta.config().getQualifiedTableName()).thenReturn("UserBean");
         when(schemaContext.entityMetaEntrySet()).thenReturn(metas.entrySet());
         when(schemaContext.hasSimpleCounter()).thenReturn(true);
+        when(schemaContext.achillesCounterTableExists()).thenReturn(true);
 
         bootstrapper.validateOrCreateTables(schemaContext);
 
@@ -195,6 +196,7 @@ public class AchillesBootstrapperTest {
         when(meta.config().getQualifiedTableName()).thenReturn("UserBean");
         when(schemaContext.entityMetaEntrySet()).thenReturn(metas.entrySet());
         when(schemaContext.hasSimpleCounter()).thenReturn(true);
+        when(schemaContext.achillesCounterTableExists()).thenReturn(false);
 
         bootstrapper.validateOrCreateTables(schemaContext);
 


### PR DESCRIPTION
It seems that the achilles counter  table name is not returned in the entity metadata thus it will be created at each start up.
Now we are checking directly for its existence before trying to create it.
