### PR TITLE
Better thread pool lifecycle management

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/utils/ConfigMap.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/utils/ConfigMap.java
@@ -18,6 +18,7 @@ package info.archinnov.achilles.internal.utils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import com.google.common.base.Supplier;
 import info.archinnov.achilles.configuration.ConfigurationParameters;
 
 public class ConfigMap extends LinkedHashMap<ConfigurationParameters, Object> {
@@ -45,6 +46,14 @@ public class ConfigMap extends LinkedHashMap<ConfigurationParameters, Object> {
             return getTyped(key);
         } else {
             return defaultValue;
+        }
+    }
+
+    public <T> T getTypedOr(ConfigurationParameters key, Supplier<T> defaultValue) {
+        if (super.containsKey(key)) {
+            return getTyped(key);
+        } else {
+            return defaultValue.get();
         }
     }
 

--- a/achilles-core/src/main/java/info/archinnov/achilles/persistence/PersistenceManagerFactory.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/persistence/PersistenceManagerFactory.java
@@ -43,7 +43,6 @@ import info.archinnov.achilles.internal.validation.Validator;
 import info.archinnov.achilles.json.JacksonMapperFactory;
 import info.archinnov.achilles.type.ConsistencyLevel;
 import info.archinnov.achilles.type.InsertStrategy;
-import org.springframework.scheduling.annotation.Async;
 
 import javax.annotation.PreDestroy;
 
@@ -681,7 +680,9 @@ public class PersistenceManagerFactory {
      */
     @PreDestroy
     public void shutDown() {
-        configContext.getExecutorService().shutdown();
+        if(this.configurationMap.getTyped(EXECUTOR_SERVICE) == null) {
+            this.configContext.getExecutorService().shutdown();
+        }
     }
 
     @Override


### PR DESCRIPTION
There are two issues in the management of the lifecycle of the thread pool :
- if the user supplied an executor, the default executor was still created and never used
- the thread pool is never closed, this is an issue because it prevents the undeploy of webapp in containers like tomcat, and even worse, produce a dirty log on shutdown ;)

This PR fixes these issues by  using a supplier to avoid creating the default executor if the user supplied one and add a close() operation on the PersistenceManagerFactory to close the default executor if the user didn't provide one.