### PR TITLE
Upgrades Achilles to work with java-driver 2.1.5

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/NullRow.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/persistence/operations/NullRow.java
@@ -27,8 +27,10 @@ import java.util.Set;
 import java.util.UUID;
 import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Token;
 import com.datastax.driver.core.TupleValue;
 import com.datastax.driver.core.UDTValue;
+import com.google.common.reflect.TypeToken;
 
 public class NullRow implements Row {
     @Override
@@ -217,12 +219,57 @@ public class NullRow implements Row {
     }
 
     @Override
+    public <T> List<T> getList(int i, TypeToken<T> elementsType) {
+        return null;
+    }
+
+    @Override
+    public <T> Set<T> getSet(int i, TypeToken<T> elementsType) {
+        return null;
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(int i, TypeToken<K> keysType, TypeToken<V> valuesType) {
+        return null;
+    }
+
+    @Override
+    public <T> List<T> getList(String name, TypeToken<T> elementsType) {
+        return null;
+    }
+
+    @Override
+    public <T> Set<T> getSet(String name, TypeToken<T> elementsType) {
+        return null;
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(String name, TypeToken<K> keysType, TypeToken<V> valuesType) {
+        return null;
+    }
+
+    @Override
     public UDTValue getUDTValue(String name) {
         return null;
     }
 
     @Override
     public TupleValue getTupleValue(String name) {
+        return null;
+    }
+
+    @Override
+    public Token getToken(int i) {
+        return null;
+    }
+
+    @Override
+    public Token getToken(String name) {
+        return null;
+    }
+
+    @Override
+    public Token getPartitionKeyToken() {
         return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cassandra.version>2.0.12</cassandra.version>
-        <datastax.driver.core.version>2.1.4</datastax.driver.core.version>
+        <datastax.driver.core.version>2.1.5</datastax.driver.core.version>
         <spring.version>3.2.0.RELEASE</spring.version>
         <cglib.version>2.2.2</cglib.version>
         <fasterxml.jackson.version>2.3.3</fasterxml.jackson.version>


### PR DESCRIPTION
Upgrades Achilles to work with java-driver 2.1.5

The java driver 2.1.5 added some nice [improvements & bigfixes](https://github.com/datastax/java-driver/blob/2.1/driver-core/CHANGELOG.rst#215) like race conditions, but compilation fails with Achilles 3.0.17.

The issue is due to improvements and new APIs on the `Row` type, those are added as part of the following tickets

- [JAVA-312](https://datastax-oss.atlassian.net/browse/JAVA-312) : Expose node token and range information
- [JAVA-570](https://datastax-oss.atlassian.net/browse/JAVA-570), [JAVA-612](https://datastax-oss.atlassian.net/browse/JAVA-612), [JAVA-672](https://datastax-oss.atlassian.net/browse/JAVA-672) : Support mapped collection types