### PR TITLE
Print the Hex string of the 16 first bytes of blob when ACHILLES_DML_STATEMENT is enabled

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/helper/LoggerHelper.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/helper/LoggerHelper.java
@@ -63,6 +63,6 @@ public abstract class LoggerHelper {
     }
 
     private static String more(int length) {
-        return ((length > HEX_STRING_LOG_LIMIT) ? "..." : "");
+        return ((length > HEX_STRING_LOG_LIMIT) ? String.format("... (%d)", length) : "");
     }
 }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/helper/LoggerHelper.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/helper/LoggerHelper.java
@@ -15,11 +15,18 @@
  */
 package info.archinnov.achilles.internal.helper;
 
+import static java.lang.Math.min;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import com.datastax.driver.core.utils.Bytes;
 import com.google.common.base.Function;
 
-public class LoggerHelper {
-	public static Function<Class<?>, String> fqcnToStringFn = new Function<Class<?>, String>() {
+public abstract class LoggerHelper {
+    public static final int HEX_STRING_LOG_LIMIT = 16;
+    public static Function<Class<?>, String> fqcnToStringFn = new Function<Class<?>, String>() {
 		@Override
 		public String apply(Class<?> clazz) {
 			return clazz.getCanonicalName();
@@ -31,4 +38,31 @@ public class LoggerHelper {
 			return field.getName();
 		}
 	};
+
+    public static List<Object> replaceByteBuffersByHexString(Object... values) {
+        ArrayList<Object> boundValues = new ArrayList<>(Arrays.asList(values));
+
+        for (int valuePos = 0; valuePos < boundValues.size(); valuePos++) {
+            Object boundValue = boundValues.get(valuePos);
+            if (boundValue instanceof ByteBuffer) {
+                ByteBuffer bbBoundedValue = (ByteBuffer) boundValue;
+                byte[] firstBytes = new byte[min(bbBoundedValue.remaining(), HEX_STRING_LOG_LIMIT)];
+                bbBoundedValue.get(firstBytes).rewind();
+                boundValues.set(valuePos, toHexString(firstBytes, bbBoundedValue.remaining()));
+            } else if (boundValue instanceof byte[]) {
+                byte[] baBoundedValue = (byte[]) boundValue;
+                byte[] firstBytes = baBoundedValue.length > HEX_STRING_LOG_LIMIT ? Arrays.copyOfRange(baBoundedValue, 0, HEX_STRING_LOG_LIMIT) : baBoundedValue;
+                boundValues.set(valuePos, toHexString(firstBytes, baBoundedValue.length));
+            }
+        }
+        return boundValues;
+    }
+
+    private static String toHexString(byte[] firstBytes, int originalLength) {
+        return Bytes.toHexString(firstBytes) + more(originalLength);
+    }
+
+    private static String more(int length) {
+        return ((length > HEX_STRING_LOG_LIMIT) ? "..." : "");
+    }
 }

--- a/achilles-core/src/main/java/info/archinnov/achilles/internal/statement/wrapper/AbstractStatementWrapper.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internal/statement/wrapper/AbstractStatementWrapper.java
@@ -17,24 +17,18 @@
 package info.archinnov.achilles.internal.statement.wrapper;
 
 import static com.datastax.driver.core.ColumnDefinitions.Definition;
+import static info.archinnov.achilles.internal.helper.LoggerHelper.replaceByteBuffersByHexString;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult.Operation;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult.Operation.INSERT;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult.Operation.UPDATE;
 import static info.archinnov.achilles.logger.AchillesLoggers.ACHILLES_DML_STATEMENT;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
-
-import info.archinnov.achilles.exception.AchillesLightWeightTransactionException;
 import java.util.concurrent.ExecutorService;
-
-import info.archinnov.achilles.listener.LWTResultListener;
-import info.archinnov.achilles.logger.AchillesLoggers;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +44,10 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.TraceRetrievalException;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ListenableFuture;
+import info.archinnov.achilles.exception.AchillesLightWeightTransactionException;
 import info.archinnov.achilles.internal.async.AsyncUtils;
 import info.archinnov.achilles.internal.reflection.RowMethodInvoker;
+import info.archinnov.achilles.listener.LWTResultListener;
 import info.archinnov.achilles.type.ConsistencyLevel;
 import info.archinnov.achilles.type.TypedMap;
 
@@ -158,7 +154,7 @@ public abstract class AbstractStatementWrapper {
         }
 
         if (ArrayUtils.isNotEmpty(values)) {
-            actualLogger.debug("\t bound values : {}", Arrays.asList(values));
+            actualLogger.debug("\t bound values : {}", replaceByteBuffersByHexString(values));
         }
     }
 

--- a/achilles-core/src/test/java/info/archinnov/achilles/LogInterceptionRule.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/LogInterceptionRule.java
@@ -1,0 +1,62 @@
+package info.archinnov.achilles;
+
+import static info.archinnov.achilles.logger.AchillesLoggers.ACHILLES_DML_STATEMENT;
+import static org.mockito.Mockito.mock;
+import java.lang.reflect.Field;
+import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.rules.ExternalResource;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.Log4jLoggerAdapter;
+
+public abstract class LogInterceptionRule extends ExternalResource {
+
+    protected Appender mockedAppender;
+    protected Level previousLevel;
+
+    public static DMLStatementInterceptor interceptDMLStatementViaMockedAppender() {
+        return new DMLStatementInterceptor();
+    }
+
+
+    public Appender appender() {
+        return mockedAppender;
+    }
+
+    protected Logger log4jLoggerAccess() {
+        try {
+            Log4jLoggerAdapter loggerAdapter = (Log4jLoggerAdapter) LoggerFactory.getLogger(ACHILLES_DML_STATEMENT);
+            Field loggerField = Log4jLoggerAdapter.class.getDeclaredField("logger");
+            loggerField.setAccessible(true);
+            return (Logger) loggerField.get(loggerAdapter);
+        } catch (NoSuchFieldException | IllegalAccessException cant_access_log4j_logger) {
+            throw new RuntimeException("Permission on this JVM doesn't allow to access this field", cant_access_log4j_logger);
+        } catch (ClassCastException cant_cast_to_log4j_logger) {
+            throw new ClassCastException("It seems the logger implementation is not log4j, please adapt this code");
+        }
+    }
+
+    public static class DMLStatementInterceptor extends LogInterceptionRule {
+        @Override
+        protected void before() {
+            Logger log4jLogger = log4jLoggerAccess();
+
+            Appender appender = mock(Appender.class);
+            log4jLogger.addAppender(appender);
+            this.mockedAppender = appender;
+
+            this.previousLevel = log4jLogger.getLevel();
+            log4jLogger.setLevel(Level.DEBUG);
+        }
+
+        @Override
+        protected void after() {
+            Logger logger = log4jLoggerAccess();
+            logger.removeAppender(mockedAppender);
+            logger.setLevel(previousLevel);
+        }
+
+
+    }
+}

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/helper/LoggerHelperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/helper/LoggerHelperTest.java
@@ -16,19 +16,35 @@
 package info.archinnov.achilles.internal.helper;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.junit.Test;
+import com.datastax.driver.core.utils.Bytes;
 import com.google.common.collect.Lists;
+import info.archinnov.achilles.internal.utils.UUIDGen;
 import info.archinnov.achilles.test.mapping.entity.CompleteBean;
 
 public class LoggerHelperTest {
 
-	@Test
+    private final byte[] long_blob = byteArrayOf("abcdefghijklmnoprstuvwxyz1234567890");
+    private final byte[] short_blob = byteArrayOf("12345678");
+    private final byte[] uuid_blob = byteArrayOf(UUIDGen.getTimeUUID());
+
+    private byte[] byteArrayOf(UUID timeUUID) {
+        return ByteBuffer.wrap(new byte[16])
+                .putLong(timeUUID.getMostSignificantBits())
+                .putLong(timeUUID.getLeastSignificantBits())
+                .array();
+    }
+
+
+    @Test
 	public void should_transform_class_list_to_canonical_class_name_list() throws Exception {
-		List<Class<?>> classes = new ArrayList<Class<?>>();
+		List<Class<?>> classes = new ArrayList<>();
 		classes.add(Long.class);
 
 		assertThat(Lists.transform(classes, LoggerHelper.fqcnToStringFn)).contains(Long.class.getCanonicalName());
@@ -37,9 +53,60 @@ public class LoggerHelperTest {
 	@Test
 	public void should_transform_field_list_to_field_name_list() throws Exception {
 		Field field = CompleteBean.class.getDeclaredField("id");
-		List<Field> fields = new ArrayList<Field>();
+		List<Field> fields = new ArrayList<>();
 		fields.add(field);
 
 		assertThat(Lists.transform(fields, LoggerHelper.fieldToStringFn)).contains("id");
 	}
+
+    @Test
+    public void should_transform_long_byte_array_to_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(new Object[] { long_blob });
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, 32 + 2) + "...");
+    }
+
+    @Test
+    public void should_transform_long_ByteBuffer_to_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(ByteBuffer.wrap(long_blob));
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, 32 + 2) + "...");
+    }
+
+    @Test
+    public void should_transform_short_byte_array_to_non_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(new Object[] { short_blob });
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(short_blob));
+    }
+
+    @Test
+    public void should_transform_short_ByteBuffer_to_non_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(ByteBuffer.wrap(short_blob));
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(short_blob));
+    }
+
+    @Test
+    public void should_transform_short_byte_array_of_a_UUID_to_non_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(new Object[] { uuid_blob });
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(uuid_blob));
+    }
+
+    @Test
+    public void should_transform_short_ByteBuffer_of_a_UUID_to_non_truncated_hex_string() throws Exception {
+        List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(ByteBuffer.wrap(uuid_blob));
+
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(uuid_blob));
+    }
+
+    private byte[] byteArrayOf(String string) {
+        try {
+            return string.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException charset_bad_luck) {
+            throw new RuntimeException("JVM failure ?", charset_bad_luck);
+        }
+    }
+
 }

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/helper/LoggerHelperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/helper/LoggerHelperTest.java
@@ -30,8 +30,10 @@ import info.archinnov.achilles.test.mapping.entity.CompleteBean;
 
 public class LoggerHelperTest {
 
+    public static final int _0x_LENGTH = 2;
     private final byte[] long_blob = byteArrayOf("abcdefghijklmnoprstuvwxyz1234567890");
     private final byte[] short_blob = byteArrayOf("12345678");
+    private final byte[] _1byte_blob = byteArrayOf("z");
     private final byte[] uuid_blob = byteArrayOf(UUIDGen.getTimeUUID());
 
     private byte[] byteArrayOf(UUID timeUUID) {
@@ -63,14 +65,14 @@ public class LoggerHelperTest {
     public void should_transform_long_byte_array_to_truncated_hex_string() throws Exception {
         List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(new Object[] { long_blob });
 
-        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, 32 + 2) + "...");
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, byteAsStringLength(16) + _0x_LENGTH) + "... (35)");
     }
 
     @Test
     public void should_transform_long_ByteBuffer_to_truncated_hex_string() throws Exception {
         List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(ByteBuffer.wrap(long_blob));
 
-        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, 32 + 2) + "...");
+        assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(long_blob).substring(0, byteAsStringLength(16) + _0x_LENGTH) + "... (35)");
     }
 
     @Test
@@ -99,6 +101,11 @@ public class LoggerHelperTest {
         List<Object> objects = LoggerHelper.replaceByteBuffersByHexString(ByteBuffer.wrap(uuid_blob));
 
         assertThat(objects.get(0)).isEqualTo(Bytes.toHexString(uuid_blob));
+    }
+
+    private int byteAsStringLength(int byteCount) {
+        // a single byte is represented by two char
+        return byteCount * 2;
     }
 
     private byte[] byteArrayOf(String string) {

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BatchStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BatchStatementWrapperTest.java
@@ -22,8 +22,6 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.util.concurrent.ExecutorService;
-
-import info.archinnov.achilles.listener.LWTResultListener;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +33,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Optional;
 import info.archinnov.achilles.internal.async.AsyncUtils;
+import info.archinnov.achilles.listener.LWTResultListener;
 import info.archinnov.achilles.type.ConsistencyLevel;
 
 

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BatchStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BatchStatementWrapperTest.java
@@ -17,7 +17,6 @@
 package info.archinnov.achilles.internal.statement.wrapper;
 
 import static com.datastax.driver.core.BatchStatement.Type.LOGGED;
-import static com.google.common.base.Optional.fromNullable;
 import static java.util.Arrays.asList;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -70,11 +69,11 @@ public class BatchStatementWrapperTest {
     public void should_get_query_string() throws Exception {
         //Given
         when(statementWrapper.getQueryString()).thenReturn("SELECT * FROM");
-        statementWrapper.lwtResultListener = Optional.fromNullable(LWTResultListener);
+        statementWrapper.lwtResultListener = Optional.of(LWTResultListener);
 
         //When
         BatchStatementWrapper wrapper = new BatchStatementWrapper(LOGGED, asList(statementWrapper),
-                fromNullable(ConsistencyLevel.ALL),fromNullable(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL));
+                Optional.of(ConsistencyLevel.ALL),Optional.of(com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL));
         final String actual = wrapper.getQueryString();
 
         //Then
@@ -95,7 +94,7 @@ public class BatchStatementWrapperTest {
     public void should_log_dml_statements() throws Exception {
         //Given
         when(statementWrapper.isTracingEnabled()).thenReturn(true);
-        statementWrapper.lwtResultListener = Optional.fromNullable(LWTResultListener);
+        statementWrapper.lwtResultListener = Optional.of(LWTResultListener);
 
         //When
         BatchStatementWrapper wrapper = new BatchStatementWrapper(LOGGED, asList(statementWrapper),

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BoundStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BoundStatementWrapperTest.java
@@ -16,7 +16,6 @@
 
 package info.archinnov.achilles.internal.statement.wrapper;
 
-import static com.google.common.base.Optional.fromNullable;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
@@ -44,7 +43,7 @@ public class BoundStatementWrapperTest {
     @Test
     public void should_get_bound_statement() throws Exception {
         //Given
-        wrapper = new BoundStatementWrapper(CompleteBean.class, bs, new Object[] { 1 }, ConsistencyLevel.ONE, NO_LISTENER, fromNullable(ConsistencyLevel.LOCAL_SERIAL));
+        wrapper = new BoundStatementWrapper(CompleteBean.class, bs, new Object[] { 1 }, ConsistencyLevel.ONE, NO_LISTENER, Optional.of(ConsistencyLevel.LOCAL_SERIAL));
 
         //When
         final BoundStatement expectedBs = wrapper.getStatement();

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BoundStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/BoundStatementWrapperTest.java
@@ -16,17 +16,25 @@
 
 package info.archinnov.achilles.internal.statement.wrapper;
 
+import static info.archinnov.achilles.LogInterceptionRule.interceptDMLStatementViaMockedAppender;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import info.archinnov.achilles.listener.LWTResultListener;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.google.common.base.Optional;
+import info.archinnov.achilles.LogInterceptionRule.DMLStatementInterceptor;
+import info.archinnov.achilles.listener.LWTResultListener;
 import info.archinnov.achilles.test.mapping.entity.CompleteBean;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -34,9 +42,14 @@ public class BoundStatementWrapperTest {
 
     private BoundStatementWrapper wrapper;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private BoundStatement bs;
 
+    @Rule
+    public DMLStatementInterceptor dmlStmntInterceptor = interceptDMLStatementViaMockedAppender();
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEvent;
 
     private static final Optional<LWTResultListener> NO_LISTENER = Optional.absent();
 
@@ -51,5 +64,22 @@ public class BoundStatementWrapperTest {
         //Then
         assertThat(expectedBs).isSameAs(bs);
         verify(bs).setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
+    }
+
+    @Test
+    public void should_log_dml_statement_with_bound_values() throws Exception {
+        //Given
+        wrapper = new BoundStatementWrapper(CompleteBean.class, bs, new Object[] { 73L, "bob" }, ConsistencyLevel.ONE, NO_LISTENER, Optional.of(ConsistencyLevel.LOCAL_SERIAL));
+        given(bs.preparedStatement().getQueryString()).willReturn("insert ...");
+
+        // When
+        wrapper.logDMLStatement("");
+
+        // Then
+        verify(dmlStmntInterceptor.appender(), times(2)).doAppend(loggingEvent.capture());
+        assertThat(loggingEvent.getAllValues().get(0).getMessage().toString())
+                .contains("[insert ...] with CONSISTENCY LEVEL [DEFAULT]");
+        assertThat(loggingEvent.getAllValues().get(1).getMessage().toString())
+                .contains("bound values : [73, bob]");
     }
 }

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/NativeStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/NativeStatementWrapperTest.java
@@ -18,23 +18,36 @@ package info.archinnov.achilles.internal.statement.wrapper;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static info.archinnov.achilles.LogInterceptionRule.interceptDMLStatementViaMockedAppender;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import java.nio.ByteBuffer;
 import java.util.UUID;
-
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.RegularStatement;
-import info.archinnov.achilles.listener.LWTResultListener;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.runners.MockitoJUnitRunner;
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.google.common.base.Optional;
+import info.archinnov.achilles.LogInterceptionRule.DMLStatementInterceptor;
+import info.archinnov.achilles.listener.LWTResultListener;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NativeStatementWrapperTest {
+
+    @Rule
+    public DMLStatementInterceptor dmlStmntInterceptor = interceptDMLStatementViaMockedAppender();
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEvent;
 
     @Test
     public void should_build_parameterized_statement() throws Exception {
@@ -75,4 +88,23 @@ public class NativeStatementWrapperTest {
         assertThat(actual.getConsistencyLevel()).isEqualTo(ConsistencyLevel.ALL);
         assertThat(actual.getSerialConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
     }
+
+    @Test
+    public void should_log_dml_of_a_native_statement() throws Exception {
+        //Given
+        final Insert statement = insertInto("test").value("id", 73L).value("value", "whatever, as replaced by a '?' when using RegularStatement.getQueryString");
+        statement.setConsistencyLevel(ConsistencyLevel.ALL);
+        statement.setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
+        final NativeStatementWrapper wrapper = new NativeStatementWrapper(NativeQueryLog.class, statement, new Object[] {}, Optional.<LWTResultListener>absent());
+
+
+        // When
+        wrapper.logDMLStatement("");
+
+        // Then
+        verify(dmlStmntInterceptor.appender(), times(1)).doAppend(loggingEvent.capture());
+        assertThat(loggingEvent.getValue().getMessage().toString())
+                .contains("[INSERT INTO test(id,value) VALUES (73,?);] with CONSISTENCY LEVEL [ALL]");
+    }
+
 }

--- a/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/RegularStatementWrapperTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/internal/statement/wrapper/RegularStatementWrapperTest.java
@@ -19,7 +19,6 @@ package info.archinnov.achilles.internal.statement.wrapper;
 import static com.datastax.driver.core.ColumnDefinitionBuilder.buildColumnDef;
 import static com.datastax.driver.core.ColumnDefinitions.Definition;
 import static com.datastax.driver.core.ConsistencyLevel.ONE;
-import static com.google.common.base.Optional.fromNullable;
 import static info.archinnov.achilles.internal.statement.wrapper.AbstractStatementWrapper.LWT_RESULT_COLUMN;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult.Operation.INSERT;
 import static info.archinnov.achilles.listener.LWTResultListener.LWTResult.Operation.UPDATE;
@@ -113,7 +112,7 @@ public class RegularStatementWrapperTest {
     @Test
     public void should_execute() throws Exception {
         //Given
-        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, NO_LISTENER, fromNullable(ConsistencyLevel.LOCAL_SERIAL));
+        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, NO_LISTENER, Optional.of(ConsistencyLevel.LOCAL_SERIAL));
         wrapper.traceQueryForEntity = true;
         wrapper.asyncUtils = asyncUtils;
         when(session.executeAsync(statementCaptor.capture())).thenReturn(resultSetFuture);
@@ -144,7 +143,7 @@ public class RegularStatementWrapperTest {
         };
 
         when(rs.getQueryString()).thenReturn("INSERT INTO table IF NOT EXISTS");
-        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, fromNullable(listener), NO_SERIAL_CONSISTENCY);
+        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, Optional.of(listener), NO_SERIAL_CONSISTENCY);
         when(resultSet.one().getBool(LWT_RESULT_COLUMN)).thenReturn(true);
 
         //When
@@ -168,7 +167,7 @@ public class RegularStatementWrapperTest {
                 atomicLWTResult.compareAndSet(null, lwtResult);
             }
         };
-        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, fromNullable(listener), NO_SERIAL_CONSISTENCY);
+        wrapper = new RegularStatementWrapper(CompleteBean.class, rs, new Object[] { 1 }, ONE, Optional.of(listener), NO_SERIAL_CONSISTENCY);
         wrapper.invoker = invoker;
         when(rs.getQueryString()).thenReturn("UPDATE table IF name='John' SET");
         when(resultSet.one()).thenReturn(row);


### PR DESCRIPTION
This PR allows to print the hexadecimal string of `byte` array or a `ByteBuffer` parameter when `ACHILLES_DML_STATEMENT` logger is enabled.

This is especially useful when debugging to find consistency issues, where the blob contains valuable information.

The impact should be fairly limited for two reasons : 

- `ACHILLES_DML_STATEMENT` is not to be enabled on prod
- The proposed change only _peek_ at the first 16 first bytes (like 2 longs), at the moment this limit is hardcoded, but it could improved later.
  If longer than 16 bytes 3 dots are appended signaling the reader that it was a longer blob in the query.