### PR TITLE
Provide a utility method to parse parameters by their names.

### DIFF
--- a/achilles-core/src/main/java/info/archinnov/achilles/configuration/ConfigurationParameters.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/configuration/ConfigurationParameters.java
@@ -276,4 +276,18 @@ public enum ConfigurationParameters {
         this.label = label;
     }
 
+    /**
+     * Small utility method that resolves a configuration based on its label.
+     * @param label the configuration label that would be populated in the map.
+     * @return the label in ConfigurationParameters format, or null if no match found.
+     */
+    public static ConfigurationParameters fromLabel(String label) {
+        for(ConfigurationParameters param : ConfigurationParameters.values()) {
+            if(param.label.equals(label)) {
+                return param;
+            }
+        }
+        return null;
+    }
+
 }

--- a/achilles-core/src/test/java/info/archinnov/achilles/configuration/ConfigurationParametersTest.java
+++ b/achilles-core/src/test/java/info/archinnov/achilles/configuration/ConfigurationParametersTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012-2014 DuyHai DOAN
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package info.archinnov.achilles.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for parsing configuration parameters.
+ */
+public class ConfigurationParametersTest {
+
+    @Test
+    public void testProperlyParsed() {
+        String key = "achilles.entity.packages";
+        ConfigurationParameters result = ConfigurationParameters.fromLabel(key);
+        Assert.assertEquals(ConfigurationParameters.ENTITY_PACKAGES, result);
+    }
+
+    @Test
+    public void testWhenNull() {
+        String key = "xx.null";
+        ConfigurationParameters result = ConfigurationParameters.fromLabel(key);
+        Assert.assertNull(result);
+    }
+}


### PR DESCRIPTION
A simple utility to look up params by name.  Since all configuration is type safe, if you're pull in configuration dynamically this helps to do that.