### PR TITLE
Upgrade cassandra version to 3.11.2 so it does not break on new jdk v…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,11 @@ Below is the compatibility matrix between **Achilles**, **Java Driver** and **Ca
 		</tr>
 	</thead>
 	<tbody>
+	    <tr>
+            <td>5.3.2 (all Cassandra versions up to 3.11.2, all DSE up to 5.1.2)</td>
+            <td>3.3.0</td>
+            <td>3.11.2</td>
+        </tr>
         <tr>
             <td>5.3.1 (all Cassandra versions up to 3.11.0, all DSE up to 5.1.2)</td>
             <td>3.3.0</td>

--- a/achilles-core/src/main/java/info/archinnov/achilles/internals/cassandra_version/V3_11_2.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internals/cassandra_version/V3_11_2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2012-2017 DuyHai DOAN
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.archinnov.achilles.internals.cassandra_version;
+
+public class V3_11_2 extends V3_11_0 {
+
+
+    public static V3_11_2 INSTANCE = new V3_11_2();
+
+    protected V3_11_2() {
+    }
+
+    @Override
+    public String version() {
+        return "3.11.2";
+    }
+}

--- a/achilles-core/src/main/java/info/archinnov/achilles/internals/parser/context/GlobalParsingContext.java
+++ b/achilles-core/src/main/java/info/archinnov/achilles/internals/parser/context/GlobalParsingContext.java
@@ -82,6 +82,7 @@ public class GlobalParsingContext {
         VERSION_MAPPING.put(CASSANDRA_3_9, V3_9.INSTANCE);
         VERSION_MAPPING.put(CASSANDRA_3_10, V3_10.INSTANCE);
         VERSION_MAPPING.put(CASSANDRA_3_11_0, V3_11_0.INSTANCE);
+        VERSION_MAPPING.put(CASSANDRA_3_11_2, V3_11_2.INSTANCE);
         VERSION_MAPPING.put(DSE_4_8_X, info.archinnov.achilles.internals.cassandra_version.DSE_4_8_X.INSTANCE);
         VERSION_MAPPING.put(DSE_5_0_0, info.archinnov.achilles.internals.cassandra_version.DSE_5_0_0.INSTANCE);
         VERSION_MAPPING.put(DSE_5_0_1, info.archinnov.achilles.internals.cassandra_version.DSE_5_0_1.INSTANCE);

--- a/achilles-model/src/main/java/info/archinnov/achilles/type/CassandraVersion.java
+++ b/achilles-model/src/main/java/info/archinnov/achilles/type/CassandraVersion.java
@@ -335,6 +335,15 @@ public enum CassandraVersion {
      */
     CASSANDRA_3_10,
     CASSANDRA_3_11_0,
+    /**
+     * New features:
+     * <br/>
+     * <ul>
+     *     <li> Fix for JDK 8u161 breaks JMX integration (CASSANDRA-14173)</li>
+     * </ul>
+     *
+     */
+    CASSANDRA_3_11_2,
 
     /**
      * Feature:

--- a/docs/README.markdown
+++ b/docs/README.markdown
@@ -45,6 +45,11 @@ Below is the compatibility matrix between **Achilles**, **Java Driver** and **Ca
 		</tr>
 	</thead>
 	<tbody>
+		<tr>
+            <td>5.3.2 (all Cassandra versions up to 3.11.2, all DSE up to 5.1.2)</td>
+            <td>3.3.0</td>
+            <td>3.11.2</td>
+        </tr>
         <tr>
             <td>5.3.1 (all Cassandra versions up to 3.11.0, all DSE up to 5.1.2)</td>
             <td>3.3.0</td>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cassandra.version>3.11.0</cassandra.version>
+        <cassandra.version>3.11.2</cassandra.version>
         <datastax.driver.core.version>3.3.0</datastax.driver.core.version>
         <fasterxml.jackson.version>2.3.3</fasterxml.jackson.version>
         <commons.lang.version>3.3.2</commons.lang.version>


### PR DESCRIPTION
Can somebody take a look at it? 

This project is kind off new for me. (haven't looked into it in detail)
The tests even fails for me when I checkout master. 
Also my IntelliJ isn't able to even compile the project. (mvn runs fine)
Thus, i'm not sure if these are all the required changes.. 