### PR TITLE
PortFinder#findFirstAvailableBetween method added.

### DIFF
--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/PortFinder.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/PortFinder.java
@@ -19,6 +19,7 @@ package info.archinnov.achilles.embedded;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
+import java.util.stream.IntStream;
 
 public class PortFinder {
 
@@ -26,6 +27,14 @@ public class PortFinder {
 
     public static int randomAvailable() {
         return findAvailableBetween(1025, 65534);
+    }
+
+    public static int findFirstAvailableBetween(int startInclusive, int endExclusive) {
+        return IntStream.range(startInclusive, endExclusive)
+            .filter(PortFinder::isAvailable)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(
+                "no available port found between " + startInclusive + " and " + endExclusive + "."));
     }
 
     public static Integer findAvailableBetween(int start, int end) {

--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter.java
@@ -72,11 +72,11 @@ public enum ServerStarter {
     }
 
     private static int cqlRandomPort() {
-        return PortFinder.findAvailableBetween(9043, 9499);
+        return PortFinder.findFirstAvailableBetween(9042, 9499);
     }
 
     private static int thriftRandomPort() {
-        return PortFinder.findAvailableBetween(9501, 9999);
+        return PortFinder.findFirstAvailableBetween(9160, 9999);
     }
 
     public void startServer(String cassandraHost, TypedMap parameters) {

--- a/achilles-embedded/src/test/java/info/archinnov/achilles/embedded/PortFinderTest.java
+++ b/achilles-embedded/src/test/java/info/archinnov/achilles/embedded/PortFinderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012-2018 DuyHai DOAN
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.archinnov.achilles.embedded;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.net.ServerSocket;
+import org.junit.Test;
+
+public class PortFinderTest {
+
+    @Test
+    public void try_to_find_first_port() throws Exception {
+        int start = 7050;
+        int result = PortFinder.findFirstAvailableBetween(start, start + 10);
+        assertThat(result).isEqualTo(start);
+
+        try(ServerSocket ss = new ServerSocket(start)) {
+            ss.setReuseAddress(true);
+            int secondResult = PortFinder.findFirstAvailableBetween(start, start + 10);
+            assertThat(secondResult).isEqualTo(start + 1);
+        }
+
+        int thirdResult = PortFinder.findFirstAvailableBetween(start, start + 10);
+        assertThat(thirdResult).isEqualTo(start);
+    }
+}


### PR DESCRIPTION
The new method tries to find the first free Port in given range.
In combination with the changes in SeverStarter the default port will be used if possible.
So the debugging with cqlsh is more easy.