### PR TITLE
Allow unit testing on modern DW

### DIFF
--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
@@ -117,6 +117,7 @@ public class AchillesInitializer {
                 .withCompression(compression).withLoadBalancingPolicy(loadBalancingPolicy).withRetryPolicy(retryPolicy)
                 .withReconnectionPolicy(reconnectionPolicy)
                 .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED)
+                .withoutJMXReporting()
                 .build();
 
         // Add Cluster for shutdown process


### PR DESCRIPTION
This is a breaking change, so perhaps not the best way to go about this, but there ought to be some option to disable JMX reporting on the embedded Cassandra server to allow compatibility with later versions of DW.

See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/