### PR TITLE
embedded: server builder now supports setting protocol version

### DIFF
--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
@@ -112,6 +112,7 @@ public class AchillesInitializer {
         final LoadBalancingPolicy loadBalancingPolicy = parameters.getTyped(LOAD_BALANCING_POLICY);
         final RetryPolicy retryPolicy = parameters.getTyped(RETRY_POLICY);
         final ReconnectionPolicy reconnectionPolicy = parameters.getTyped(RECONNECTION_POLICY);
+        final ProtocolVersion protocolVersion = parameters.getTypedOr(CASSANDRA_CONNECTION_PROTOCOL_VERSION,ProtocolVersion.NEWEST_SUPPORTED);
         final SocketOptions socketOptions = new SocketOptions();
         socketOptions.setKeepAlive(true);
         socketOptions.setConnectTimeoutMillis(15000);
@@ -125,7 +126,7 @@ public class AchillesInitializer {
                 .withLoadBalancingPolicy(loadBalancingPolicy)
                 .withRetryPolicy(retryPolicy)
                 .withReconnectionPolicy(reconnectionPolicy)
-                .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED)
+                .withProtocolVersion(protocolVersion)
                 .withSocketOptions(socketOptions)
                 .withoutJMXReporting()
                 .build();

--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/CassandraEmbeddedConfigParameters.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/CassandraEmbeddedConfigParameters.java
@@ -68,6 +68,8 @@ public class CassandraEmbeddedConfigParameters {
 
     public static final String CASSANDRA_CQL_PORT = "cqlPort";
 
+    public static final String CASSANDRA_CONNECTION_PROTOCOL_VERSION = "connectionProtocolVersion";
+
     public static final String CASSANDRA_STORAGE_PORT = "storagePort";
 
     public static final String CASSANDRA_STORAGE_SSL_PORT = "storageSSLPort";

--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/CassandraEmbeddedServerBuilder.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/CassandraEmbeddedServerBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
 
 import info.archinnov.achilles.type.TypedMap;
@@ -87,6 +88,8 @@ public class CassandraEmbeddedServerBuilder {
     private int concurrentWrites;
 
     private int cqlPort;
+
+    private ProtocolVersion protocolVersion;
 
     private int jmxPort;
 
@@ -313,6 +316,18 @@ public class CassandraEmbeddedServerBuilder {
      */
     public CassandraEmbeddedServerBuilder withCQLPort(int clqPort) {
         this.cqlPort = clqPort;
+        return this;
+    }
+
+    /**
+     * Specify the connection protocol version for the embedded Cassandra
+     * server. If not set, the version will be the newest supported.
+     *
+     * @param protocolVersion connection protocol version
+     * @return CassandraEmbeddedServerBuilder
+     */
+    public CassandraEmbeddedServerBuilder withConnectionProtocol(ProtocolVersion protocolVersion) {
+        this.protocolVersion = protocolVersion;
         return this;
     }
 


### PR DESCRIPTION
If not supplied the ProtocolVersion.NEWEST_SUPPORTED will be used
in order to maintain backwards compatibility.

Fixes: #374  