### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
         <clean.data.files>true</clean.data.files>
         <joda-time.version>2.9.1</joda-time.version>
         <asm.version>5.0.4</asm.version>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,9 @@
                     </systemPropertyVariables>
                     <workingDirectory>${basedir}/..</workingDirectory>
                     <argLine>-Duser.language=en</argLine>
+                    <parallel>classes</parallel>
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
+                    <disableXmlReport>${closeTestReports}</disableXmlReport>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
