### PR TITLE
Fix Flaky Test

### DIFF
--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/AchillesInitializer.java
@@ -60,6 +60,9 @@ public class AchillesInitializer {
             if (STARTED.get() == false) {
                 LOGGER.debug("Creating cluster and session singletons");
                 singletonCluster = initializeCluster(cassandraHost, parameters);
+                while (!ServerStarter.hasExecutionStatus()) { 
+                    Thread.yield(); 
+                }
                 final Session tempSession = singletonCluster.connect();
                 createKeyspaceIfNeeded(tempSession, keyspaceName, durableWrite);
                 tempSession.close();

--- a/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter.java
+++ b/achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter.java
@@ -52,6 +52,7 @@ import info.archinnov.achilles.validation.Validator;
 public enum ServerStarter {
     CASSANDRA_EMBEDDED;
 
+    private static volatile boolean hasExecuted;
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerStarter.class);
 
     private static final OrderedShutdownHook orderedShutdownHook = new OrderedShutdownHook();
@@ -114,6 +115,10 @@ public enum ServerStarter {
         return orderedShutdownHook;
     }
 
+    public static boolean hasExecutionStatus() {
+        return hasExecuted;
+    }
+
     private void start(final TypedMap parameters) {
         if (isAlreadyRunning() && CassandraEmbeddedServer.embeddedServerStarted == true) {
             LOGGER.debug("Cassandra is already running, not starting new one");
@@ -161,6 +166,7 @@ public enum ServerStarter {
 
             cassandraDaemon.completeSetup();
             cassandraDaemon.activate();
+            hasExecuted = true;
             daemonRef.getAndSet(cassandraDaemon);
             startupLatch.countDown();
         });


### PR DESCRIPTION
### What changes were proposed in this pull request?

I observe that a test (info.archinnov.achilles.it.TestALLEntityAsChild.should_insert) is a flaky test than can fail due to the slow execution of achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter#L159. When ServerStarter.java#159 is not executed quick enough, the method (initializeFromParameters) tries to connect the cluster given at Line 63, then fails. While it may be possible to fix this flaky test by adding a waiting time before the execution of this line, but I believe such a fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. Hence, I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the code location that needs to be executed before making the connection with the cluster (achilles-embedded/src/main/java/info/archinnov/achilles/embedded/ServerStarter#L159), so I introduce one variable in this class that is only there to provide some synchronization. Basically, until these statements are executed, I force the thread that the test runs to wait before it proceeds to the assertions.

### Why are the changes needed?

[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 30.377 s <<< FAILURE! - in info.archinnov.achilles.it.TestALLEntityAsChild
[ERROR] should_insert(info.archinnov.achilles.it.TestALLEntityAsChild)  Time elapsed: 30.377 s  <<< ERROR!
com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: localhost/127.0.0.1:9042 (com.datastax.driver.core.exceptions.TransportException: [localhost/127.0.0.1:9042] Cannot connect))
	at info.archinnov.achilles.it.TestALLEntityAsChild.<init>(TestALLEntityAsChild.java:49)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   TestALLEntityAsChild.<init>:49 » NoHostAvailable All host(s) tried for query f...
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0

### How was this patch tested?

I run this test more than 1000 times and the test always passes.